### PR TITLE
Atmosphere scattering glow

### DIFF
--- a/src/planets.json
+++ b/src/planets.json
@@ -50,6 +50,22 @@
     "daylength": 2802,
     "cloudPeriod": 96,
     "atmosphereOpacity": 0.9,
+    "atmosphereGlow": {
+      "color": [
+        0.96,
+        0.9,
+        0.72
+      ],
+      "mieColor": [
+        1.0,
+        0.92,
+        0.7
+      ],
+      "intensity": 0.5,
+      "scale": 1.042,
+      "height": 0.012,
+      "mie": 0.45
+    },
     "type": "planet",
     "orbits": "Sun",
     "tilt": 2.64,
@@ -69,6 +85,22 @@
     "period": 365,
     "daylength": 24,
     "cloudPeriod": 21,
+    "atmosphereGlow": {
+      "color": [
+        0.28,
+        0.52,
+        1.0
+      ],
+      "mieColor": [
+        1.0,
+        0.68,
+        0.38
+      ],
+      "intensity": 1.4,
+      "scale": 1.038,
+      "height": 0.01,
+      "mie": 0.32
+    },
     "type": "planet",
     "orbits": "Sun",
     "tilt": 23.44,
@@ -127,6 +159,22 @@
     "distance": 247,
     "period": 686,
     "daylength": 24.7,
+    "atmosphereGlow": {
+      "color": [
+        0.82,
+        0.5,
+        0.32
+      ],
+      "mieColor": [
+        0.95,
+        0.48,
+        0.22
+      ],
+      "intensity": 0.78,
+      "scale": 1.034,
+      "height": 0.01,
+      "mie": 0.4
+    },
     "type": "planet",
     "orbits": "Sun",
     "tilt": 25.19,
@@ -190,6 +238,22 @@
     "distance": 741,
     "period": 4332,
     "daylength": 9.9,
+    "atmosphereGlow": {
+      "color": [
+        0.72,
+        0.78,
+        0.95
+      ],
+      "mieColor": [
+        1.0,
+        0.86,
+        0.65
+      ],
+      "intensity": 1.38,
+      "scale": 1.034,
+      "height": 0.008,
+      "mie": 0.22
+    },
     "type": "planet",
     "orbits": "Sun",
     "tilt": 3.13,
@@ -216,6 +280,22 @@
     "distance": 1463,
     "period": 10755,
     "daylength": 10.7,
+    "atmosphereGlow": {
+      "color": [
+        0.92,
+        0.86,
+        0.7
+      ],
+      "mieColor": [
+        1.0,
+        0.9,
+        0.62
+      ],
+      "intensity": 0.88,
+      "scale": 1.012,
+      "height": 0.004,
+      "mie": 0.14
+    },
     "type": "planet",
     "orbits": "Sun",
     "tilt": 26.73,
@@ -242,6 +322,22 @@
     "distance": 2938,
     "period": 30687,
     "daylength": 17.2,
+    "atmosphereGlow": {
+      "color": [
+        0.38,
+        0.8,
+        0.84
+      ],
+      "mieColor": [
+        0.78,
+        0.94,
+        0.95
+      ],
+      "intensity": 0.55,
+      "scale": 1.042,
+      "height": 0.07,
+      "mie": 0.1
+    },
     "type": "planet",
     "orbits": "Sun",
     "tilt": 82.23,
@@ -258,6 +354,22 @@
     "distance": 4474,
     "period": 60190,
     "daylength": 16.1,
+    "atmosphereGlow": {
+      "color": [
+        0.32,
+        0.52,
+        1.0
+      ],
+      "mieColor": [
+        0.55,
+        0.72,
+        1.0
+      ],
+      "intensity": 1.25,
+      "scale": 1.038,
+      "height": 0.014,
+      "mie": 0.12
+    },
     "type": "planet",
     "orbits": "Sun",
     "tilt": 28.32,
@@ -314,6 +426,22 @@
     "distance": 1.2,
     "period": 15.95,
     "daylength": 10.7,
+    "atmosphereGlow": {
+      "color": [
+        0.92,
+        0.48,
+        0.16
+      ],
+      "mieColor": [
+        1.0,
+        0.58,
+        0.22
+      ],
+      "intensity": 0.355,
+      "scale": 1.0425,
+      "height": 0.013,
+      "mie": 0.7
+    },
     "type": "moon",
     "orbits": "Saturn",
     "tilt": 27,

--- a/src/planets.json
+++ b/src/planets.json
@@ -249,10 +249,10 @@
         0.86,
         0.65
       ],
-      "intensity": 1.38,
-      "scale": 1.034,
+      "intensity": 1.08,
+      "scale": 1.024,
       "height": 0.008,
-      "mie": 0.22
+      "mie": 0.18
     },
     "type": "planet",
     "orbits": "Sun",

--- a/src/setup/atmosphere-glow.ts
+++ b/src/setup/atmosphere-glow.ts
@@ -1,0 +1,157 @@
+import * as THREE from "three";
+
+export interface AtmosphereGlowParams {
+  /** Limb scatter colour (linear RGB). */
+  color: [number, number, number];
+  /** Sunset colour on the terminator. Defaults to a warm white. */
+  mieColor?: [number, number, number];
+  /** Exposure. 1 is a faint limb. */
+  intensity: number;
+  /** Atmosphere radius as a multiple of the body radius. */
+  scale: number;
+  /** Scale height as a fraction of body radius. Thinner = sharper limb. */
+  height: number;
+  /** Mie strength; boosts the sunward limb. */
+  mie?: number;
+}
+
+const DEFAULT_MIE_COLOR: [number, number, number] = [1.0, 0.78, 0.48];
+
+let sharedGeometry: THREE.SphereGeometry | null = null;
+
+const getGeometry = (): THREE.SphereGeometry => {
+  if (!sharedGeometry) {
+    sharedGeometry = new THREE.SphereGeometry(1, 72, 72);
+  }
+  return sharedGeometry;
+};
+
+const glowVertex = /* glsl */ `
+  varying vec3 vViewNormal;
+  varying vec3 vWorldNormal;
+  varying vec3 vPlanetCenter;
+  varying vec3 vWorldPosition;
+
+  void main() {
+    vec4 world = modelMatrix * vec4(position, 1.0);
+    vWorldPosition = world.xyz;
+    vPlanetCenter = modelMatrix[3].xyz;
+    vWorldNormal = normalize(mat3(modelMatrix) * normal);
+    vViewNormal = normalize(normalMatrix * normal);
+    gl_Position = projectionMatrix * viewMatrix * world;
+  }
+`;
+
+const glowFragment = /* glsl */ `
+  uniform vec3 uColor;
+  uniform vec3 uSunset;
+  uniform float uIntensity;
+  uniform float uPower;
+  uniform float uBias;
+  uniform float uInner;
+  uniform float uMieBoost;
+
+  varying vec3 vViewNormal;
+  varying vec3 vWorldNormal;
+  varying vec3 vPlanetCenter;
+  varying vec3 vWorldPosition;
+
+  void main() {
+    vec3 viewN = normalize(vViewNormal);
+    vec3 worldN = normalize(vWorldNormal);
+    vec3 sunDir = normalize(-vPlanetCenter);
+    vec3 viewDir = normalize(cameraPosition - vWorldPosition);
+
+    float ndotv = dot(viewN, vec3(0.0, 0.0, 1.0));
+    float rim = pow(max(0.0, uBias - ndotv), uPower);
+    if (uInner > 0.5) {
+      rim = pow(max(0.0, 1.0 - max(ndotv, 0.0)), uPower);
+    }
+
+    float ndotl = dot(worldN, sunDir);
+    // Atmosphere stays lit a little past the ground terminator.
+    float daylight = smoothstep(-0.22, 0.48, ndotl);
+    float twilight = exp(-ndotl * ndotl * 5.5);
+    float wrap = daylight * 0.88 + twilight * 0.22;
+
+    // Forward scatter when the sun sits near the limb.
+    float towardSun = pow(max(0.0, dot(-viewDir, sunDir)), 4.0);
+
+    vec3 color = mix(uSunset, uColor, clamp(ndotl * 0.55 + 0.5, 0.0, 1.0));
+    float glow = rim * wrap * uIntensity;
+    glow += rim * towardSun * uIntensity * (0.4 + uMieBoost * 1.15);
+
+    if (glow < 0.004) {
+      discard;
+    }
+
+    gl_FragColor = vec4(color * glow, 1.0);
+  }
+`;
+
+const makeMaterial = (
+  params: AtmosphereGlowParams,
+  inner: boolean
+): THREE.ShaderMaterial => {
+  const sunset = params.mieColor ?? DEFAULT_MIE_COLOR;
+  const height = params.height;
+  const innerPower = THREE.MathUtils.clamp(3.1 + (0.02 - height) * 40.0, 2.7, 5.5);
+  const outerPower = THREE.MathUtils.clamp(2.4 + (0.02 - height) * 28.0, 2.0, 4.0);
+  const innerIntensity = params.intensity * 0.25;
+  const outerIntensity = params.intensity * 1.6;
+
+  return new THREE.ShaderMaterial({
+    uniforms: {
+      uColor: { value: new THREE.Color().fromArray(params.color) },
+      uSunset: { value: new THREE.Color().fromArray(sunset) },
+      uIntensity: { value: inner ? innerIntensity : outerIntensity },
+      uPower: { value: inner ? innerPower : outerPower },
+      uBias: { value: inner ? 0.0 : 0.63 },
+      uInner: { value: inner ? 1 : 0 },
+      uMieBoost: { value: params.mie ?? 0.3 },
+    },
+    vertexShader: glowVertex,
+    fragmentShader: glowFragment,
+    side: inner ? THREE.FrontSide : THREE.BackSide,
+    blending: THREE.AdditiveBlending,
+    transparent: true,
+    depthWrite: false,
+    depthTest: true,
+    toneMapped: false,
+  });
+};
+
+const decorate = (mesh: THREE.Mesh, name: string): THREE.Mesh => {
+  mesh.name = name;
+  mesh.renderOrder = 2;
+  mesh.castShadow = false;
+  mesh.receiveShadow = false;
+  mesh.raycast = () => {};
+  mesh.userData.ignorePick = true;
+  return mesh;
+};
+
+export const createAtmosphereGlow = (
+  radius: number,
+  params: AtmosphereGlowParams
+): THREE.Group => {
+  const group = new THREE.Group();
+  group.name = "atmosphere-glow";
+
+  const inner = decorate(
+    new THREE.Mesh(getGeometry(), makeMaterial(params, true)),
+    "atmosphere-glow-inner"
+  );
+  inner.scale.setScalar(radius * (1 + (params.scale - 1) * 0.22));
+
+  const outer = decorate(
+    new THREE.Mesh(getGeometry(), makeMaterial(params, false)),
+    "atmosphere-glow-outer"
+  );
+  outer.scale.setScalar(radius * params.scale);
+
+  group.add(inner, outer);
+  group.raycast = () => {};
+  group.userData.ignorePick = true;
+  return group;
+};

--- a/src/setup/planetary-object.ts
+++ b/src/setup/planetary-object.ts
@@ -3,6 +3,10 @@ import { createRingMesh } from "./rings";
 import { createPath } from "./path";
 import { loadTexture } from "./textures";
 import { applyNightLights } from "./night-lights";
+import {
+  createAtmosphereGlow,
+  type AtmosphereGlowParams,
+} from "./atmosphere-glow";
 import { Label } from "./label";
 import { PointOfInterest } from "./label";
 import { LAYERS } from "../constants";
@@ -26,8 +30,10 @@ export interface Body {
   traversable: boolean;
   offset?: number;
   stats?: Array<[string, string]>;
-  /** 0–1 opacity of the atmosphere mesh. Defaults to 1. */
+  /** 0–1 opacity of the cloud-layer mesh. Defaults to 1. */
   atmosphereOpacity?: number;
+  /** Limb haze for bodies with a visible atmosphere. */
+  atmosphereGlow?: AtmosphereGlowParams;
 }
 
 interface TexturePaths {
@@ -70,6 +76,7 @@ export class PlanetaryObject {
   tilt: number; // degrees
   mesh: THREE.Mesh;
   atmosphereMesh?: THREE.Mesh;
+  glowMesh?: THREE.Object3D;
   path?: THREE.Mesh;
   rng: number;
   map!: THREE.Texture;
@@ -111,6 +118,11 @@ export class PlanetaryObject {
     if (this.atmosphere.map) {
       this.atmosphereMesh = this.createAtmosphereMesh();
       this.mesh.add(this.atmosphereMesh);
+    }
+
+    if (body.atmosphereGlow) {
+      this.glowMesh = createAtmosphereGlow(this.radius, body.atmosphereGlow);
+      this.mesh.add(this.glowMesh);
     }
 
     this.initLabels(body.labels);
@@ -233,6 +245,7 @@ export class PlanetaryObject {
 
     const sphere = new THREE.Mesh(geometry, material);
     sphere.name = "clouds";
+    sphere.renderOrder = 1;
     sphere.receiveShadow = true;
     return sphere;
   };


### PR DESCRIPTION
Adds a per-body limb glow so atmospheres read as a thin scattering halo rather than only a cloud texture.

- Shader-based inner/outer glow with colour, sunset (Mie), intensity, scale, and scale height
- Tune glow independently in `planets.json` for Venus, Earth, Mars, the giants, and Titan
- Attach the glow to the planet mesh and keep cloud layers above the surface