### PR TITLE
Atmosphere colour and glow

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -20,7 +20,6 @@
   <div id="intro" class="intro" role="dialog" aria-modal="true" aria-busy="true" aria-labelledby="intro-title"
     aria-describedby="intro-body">
     <div class="intro-panel">
-      <p class="intro-kicker">Created by Kyle Gough</p>
       <h1 id="intro-title">Solar System Model</h1>
       <p class="intro-body" id="intro-body">
         An interactive 3D model of the Sun, planets, and major moons, with orbits,
@@ -70,15 +69,18 @@
     </aside>
   </div>
   <div class="btn-group" role="toolbar" aria-label="View controls">
-    <a class="hud-ctrl" id="btn-github" href="https://github.com/KyleGough/solar-system" target="_blank"
-      rel="noopener noreferrer" aria-label="View source">
+    <button class="hud-ctrl" id="btn-run" type="button" aria-label="Pause simulation" aria-pressed="true">
       <span class="hud-ctrl-disc" aria-hidden="true">
-        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-          <path d="M8.5 7 4 12l4.5 5M15.5 7 20 12l-4.5 5" />
+        <svg class="icon-pause" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+          <rect class="is-fill" x="7.6" y="6.6" width="2.8" height="10.8" rx="0.6" />
+          <rect class="is-fill" x="13.6" y="6.6" width="2.8" height="10.8" rx="0.6" />
+        </svg>
+        <svg class="icon-play" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+          <path class="is-fill" d="M9 6.8v10.4L18.6 12z" />
         </svg>
       </span>
-      <span class="hud-ctrl-label">Source</span>
-    </a>
+      <span class="hud-ctrl-label">Pause</span>
+    </button>
     <button class="hud-ctrl" id="btn-labels" type="button" aria-label="Show labels" aria-pressed="true">
       <span class="hud-ctrl-disc" aria-hidden="true">
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
@@ -106,11 +108,12 @@
       </span>
       <span class="hud-ctrl-label">Spin</span>
     </button>
-    <button class="hud-ctrl" id="btn-settings" type="button" aria-label="Simulation controls" aria-pressed="false">
+    <button class="hud-ctrl" id="btn-settings" type="button" aria-label="Simulation controls" aria-pressed="false" hidden>
       <span class="hud-ctrl-disc" aria-hidden="true">
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
           <circle cx="12" cy="12" r="3" />
-          <path d="M12 5.2v-2M12 20.8v-2M18.8 12h2M3.2 12h2M16.6 7.4l1.5-1.5M5.9 18.1l1.5-1.5M16.6 16.6l1.5 1.5M5.9 5.9l1.5 1.5" />
+          <path
+            d="M12 5.2v-2M12 20.8v-2M18.8 12h2M3.2 12h2M16.6 7.4l1.5-1.5M5.9 18.1l1.5-1.5M16.6 16.6l1.5 1.5M5.9 5.9l1.5 1.5" />
         </svg>
       </span>
       <span class="hud-ctrl-label">Controls</span>

--- a/src/planets.json
+++ b/src/planets.json
@@ -357,19 +357,19 @@
     "daylength": 16.1,
     "atmosphereGlow": {
       "color": [
-        0.32,
-        0.52,
-        1.0
+        0.28,
+        0.48,
+        0.78
       ],
       "mieColor": [
-        0.55,
-        0.72,
-        1.0
+        0.48,
+        0.66,
+        0.88
       ],
-      "intensity": 1.25,
-      "scale": 1.038,
-      "height": 0.014,
-      "mie": 0.12
+      "intensity": 0.5,
+      "scale": 1.028,
+      "height": 0.02,
+      "mie": 0.32
     },
     "type": "planet",
     "orbits": "Sun",

--- a/src/planets.json
+++ b/src/planets.json
@@ -335,14 +335,15 @@
         0.84
       ],
       "mieColor": [
-        0.78,
-        0.94,
-        0.95
+        1,
+        1,
+        1
       ],
-      "intensity": 0.55,
-      "scale": 1.042,
-      "height": 0.07,
-      "mie": 0.1
+      "intensity": 4,
+      "scale": 0.98,
+      "height": 0.003,
+      "mie": 1.19,
+      "scatter": 0.82
     },
     "type": "planet",
     "orbits": "Sun",

--- a/src/planets.json
+++ b/src/planets.json
@@ -52,20 +52,20 @@
     "atmosphereOpacity": 0.9,
     "atmosphereGlow": {
       "color": [
-        0.96,
-        0.9,
-        0.72
+        0.9255,
+        0.8235,
+        0.5176
       ],
       "mieColor": [
-        1,
-        0.92,
-        0.7
+        0.702,
+        0.6,
+        0.302
       ],
-      "intensity": 1.12,
-      "scale": 0.9645,
-      "height": 0.062,
-      "mie": 1.14,
-      "scatter": 0.73
+      "intensity": 2.43,
+      "scale": 0.996,
+      "height": 0,
+      "mie": 0.43,
+      "scatter": 0.93
     },
     "type": "planet",
     "orbits": "Sun",
@@ -90,17 +90,18 @@
       "color": [
         0.28,
         0.52,
-        1.0
+        1
       ],
       "mieColor": [
-        1.0,
+        1,
         0.68,
         0.38
       ],
-      "intensity": 1.4,
-      "scale": 1.038,
-      "height": 0.01,
-      "mie": 0.32
+      "intensity": 0.28,
+      "scale": 1.027,
+      "height": 0.016,
+      "mie": 0.32,
+      "scatter": 0.42
     },
     "type": "planet",
     "orbits": "Sun",
@@ -171,11 +172,11 @@
         0.0941,
         0.0157
       ],
-      "intensity": 0.81,
-      "scale": 0.9645,
-      "height": 0.016,
-      "mie": 0.25,
-      "scatter": 0.59
+      "intensity": 1.17,
+      "scale": 0.98,
+      "height": 0.022,
+      "mie": 0.56,
+      "scatter": 0.32
     },
     "type": "planet",
     "orbits": "Sun",
@@ -368,11 +369,11 @@
         0.66,
         0.88
       ],
-      "intensity": 0.5,
-      "scale": 1.028,
-      "height": 0.02,
-      "mie": 0.32,
-      "scatter": 1
+      "intensity": 0.81,
+      "scale": 0.98,
+      "height": 0,
+      "mie": 0.43,
+      "scatter": 0.36
     },
     "type": "planet",
     "orbits": "Sun",

--- a/src/planets.json
+++ b/src/planets.json
@@ -57,14 +57,15 @@
         0.72
       ],
       "mieColor": [
-        1.0,
+        1,
         0.92,
         0.7
       ],
-      "intensity": 0.5,
-      "scale": 1.042,
-      "height": 0.012,
-      "mie": 0.45
+      "intensity": 1.12,
+      "scale": 0.9645,
+      "height": 0.062,
+      "mie": 1.14,
+      "scatter": 0.73
     },
     "type": "planet",
     "orbits": "Sun",
@@ -161,19 +162,20 @@
     "daylength": 24.7,
     "atmosphereGlow": {
       "color": [
-        0.82,
-        0.5,
-        0.32
+        0.6549,
+        0.3412,
+        0.1725
       ],
       "mieColor": [
-        0.95,
-        0.48,
-        0.22
+        0.2431,
+        0.0941,
+        0.0157
       ],
-      "intensity": 0.78,
-      "scale": 1.034,
-      "height": 0.01,
-      "mie": 0.4
+      "intensity": 0.81,
+      "scale": 0.9645,
+      "height": 0.016,
+      "mie": 0.25,
+      "scatter": 0.59
     },
     "type": "planet",
     "orbits": "Sun",
@@ -369,7 +371,8 @@
       "intensity": 0.5,
       "scale": 1.028,
       "height": 0.02,
-      "mie": 0.32
+      "mie": 0.32,
+      "scatter": 1
     },
     "type": "planet",
     "orbits": "Sun",

--- a/src/planets.json
+++ b/src/planets.json
@@ -248,14 +248,15 @@
         0.95
       ],
       "mieColor": [
-        1.0,
+        1,
         0.86,
         0.65
       ],
-      "intensity": 1.08,
-      "scale": 1.024,
-      "height": 0.008,
-      "mie": 0.18
+      "intensity": 4,
+      "scale": 0.958,
+      "height": 0,
+      "mie": 0.51,
+      "scatter": 0.82
     },
     "type": "planet",
     "orbits": "Sun",

--- a/src/planets.json
+++ b/src/planets.json
@@ -291,14 +291,15 @@
         0.7
       ],
       "mieColor": [
-        1.0,
-        0.9,
-        0.62
+        0.9176,
+        0.6667,
+        0
       ],
-      "intensity": 0.88,
-      "scale": 1.012,
-      "height": 0.004,
-      "mie": 0.14
+      "intensity": 2.17,
+      "scale": 0.9645,
+      "height": 0,
+      "mie": 0.82,
+      "scatter": 0.79
     },
     "type": "planet",
     "orbits": "Sun",

--- a/src/planets.json
+++ b/src/planets.json
@@ -440,14 +440,15 @@
         0.16
       ],
       "mieColor": [
-        1.0,
+        1,
         0.58,
         0.22
       ],
-      "intensity": 0.355,
-      "scale": 1.0425,
-      "height": 0.013,
-      "mie": 0.7
+      "intensity": 0.86,
+      "scale": 1.0115,
+      "height": 0,
+      "mie": 0.7,
+      "scatter": 0.32
     },
     "type": "moon",
     "orbits": "Saturn",

--- a/src/script.ts
+++ b/src/script.ts
@@ -310,7 +310,7 @@ fakeCamera.layers.enable(LAYERS.POILabel);
 fakeCamera.layers.enable(LAYERS.SUN_SPOT);
 
 // GUI
-const gui = createGUI(clock, fakeCamera, lights, (ride) => {
+const gui = createGUI(clock, fakeCamera, lights, solarSystem, (ride) => {
   poiForcedSpin = false;
   focusTransition.setRideSpin(ride, options.focus);
 });

--- a/src/script.ts
+++ b/src/script.ts
@@ -28,7 +28,7 @@ import {
 import { LAYERS } from "./constants";
 import type { PointOfInterest } from "./setup/label";
 
-THREE.ColorManagement.enabled = false;
+THREE.ColorManagement.enabled = true;
 
 // Canvas
 const canvas = document.querySelector("canvas.webgl") as HTMLElement;
@@ -290,7 +290,9 @@ const renderer = new THREE.WebGLRenderer({
   antialias: true,
 });
 
-renderer.outputColorSpace = THREE.LinearSRGBColorSpace;
+renderer.outputColorSpace = THREE.SRGBColorSpace;
+renderer.toneMapping = THREE.ACESFilmicToneMapping;
+renderer.toneMappingExposure = 1.15;
 renderer.setSize(sizes.width, sizes.height);
 renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
 setTrailResolution(sizes.width, sizes.height);

--- a/src/setup/atmosphere-glow.ts
+++ b/src/setup/atmosphere-glow.ts
@@ -13,15 +13,24 @@ export interface AtmosphereGlowParams {
   height: number;
   /** Mie strength; boosts the sunward limb. */
   mie?: number;
+  /**
+   * Optical scatter. Higher values extinguish light past the terminator so
+   * the night side does not keep a full atmospheric halo.
+   */
+  scatter?: number;
 }
 
-const DEFAULT_MIE_COLOR: [number, number, number] = [1.0, 0.78, 0.48];
+export const DEFAULT_MIE_COLOR: [number, number, number] = [1.0, 0.78, 0.48];
+/** Extra outer radius so the fade to zero is not clipped by the mesh. */
+const OUTER_EXTEND = 1.06;
+const INNER_INTENSITY = 0.25;
+const OUTER_INTENSITY = 2.0;
 
 let sharedGeometry: THREE.SphereGeometry | null = null;
 
 const getGeometry = (): THREE.SphereGeometry => {
   if (!sharedGeometry) {
-    sharedGeometry = new THREE.SphereGeometry(1, 72, 72);
+    sharedGeometry = new THREE.SphereGeometry(1, 96, 96);
   }
   return sharedGeometry;
 };
@@ -31,6 +40,8 @@ const glowVertex = /* glsl */ `
   varying vec3 vWorldNormal;
   varying vec3 vPlanetCenter;
   varying vec3 vWorldPosition;
+  varying vec3 vViewPos;
+  varying vec3 vCenterView;
 
   void main() {
     vec4 world = modelMatrix * vec4(position, 1.0);
@@ -38,6 +49,8 @@ const glowVertex = /* glsl */ `
     vPlanetCenter = modelMatrix[3].xyz;
     vWorldNormal = normalize(mat3(modelMatrix) * normal);
     vViewNormal = normalize(normalMatrix * normal);
+    vViewPos = (viewMatrix * world).xyz;
+    vCenterView = (viewMatrix * vec4(modelMatrix[3].xyz, 1.0)).xyz;
     gl_Position = projectionMatrix * viewMatrix * world;
   }
 `;
@@ -50,11 +63,15 @@ const glowFragment = /* glsl */ `
   uniform float uBias;
   uniform float uInner;
   uniform float uMieBoost;
+  uniform float uScatter;
+  uniform float uPlanetRatio;
 
   varying vec3 vViewNormal;
   varying vec3 vWorldNormal;
   varying vec3 vPlanetCenter;
   varying vec3 vWorldPosition;
+  varying vec3 vViewPos;
+  varying vec3 vCenterView;
 
   void main() {
     vec3 viewN = normalize(vViewNormal);
@@ -69,19 +86,46 @@ const glowFragment = /* glsl */ `
     }
 
     float ndotl = dot(worldN, sunDir);
-    // Atmosphere stays lit a little past the ground terminator.
-    float daylight = smoothstep(-0.22, 0.48, ndotl);
-    float twilight = exp(-ndotl * ndotl * 5.5);
-    float wrap = daylight * 0.88 + twilight * 0.22;
+    // From the sun the silhouette is the terminator (ndotl ~ 0), so wrap
+    // cannot distinguish a dayside rim from a night-side ring. Fade wrap
+    // tightness with whether the camera is on the sunlit side instead.
+    float viewSun = dot(normalize(cameraPosition - vPlanetCenter), sunDir);
+    float daysideView = smoothstep(-0.15, 0.4, viewSun);
+    float viewAdapt = mix(1.0, daysideView, uScatter);
+
+    float wrapLo = mix(0.06, -0.22, viewAdapt);
+    float wrapHi = mix(0.42, 0.48, viewAdapt);
+    float daylight = smoothstep(wrapLo, wrapHi, ndotl);
+    float twilight = exp(-ndotl * ndotl * mix(16.0, 5.5, viewAdapt));
+    float wrap = daylight * 0.88 + twilight * mix(0.04, 0.22, viewAdapt);
 
     // Forward scatter when the sun sits near the limb.
     float towardSun = pow(max(0.0, dot(-viewDir, sunDir)), 4.0);
+    towardSun *= mix(1.0, wrap, uScatter);
 
     vec3 color = mix(uSunset, uColor, clamp(ndotl * 0.55 + 0.5, 0.0, 1.0));
     float glow = rim * wrap * uIntensity;
     glow += rim * towardSun * uIntensity * (0.4 + uMieBoost * 1.15);
+    glow *= mix(1.0, smoothstep(-0.7, -0.05, viewSun), uScatter);
 
-    if (glow < 0.004) {
+    // Apparent height: 0 at the planet disk, 1 at this shell's mesh.
+    // The outer mesh is larger than the visual atmosphere (OUTER_EXTEND) so
+    // we can fade to zero in that padding. Fading from the surface killed
+    // the whole visible ring — that ring is the only unoccluded outer glow.
+    float dist = length(vCenterView);
+    float meshR = length(vViewPos - vCenterView);
+    float pixelAng = acos(clamp(dot(normalize(vViewPos), normalize(vCenterView)), -1.0, 1.0));
+    float meshAng = asin(clamp(meshR / max(dist, meshR + 1e-4), 0.0, 0.999));
+    float planetAng = asin(clamp(meshR * uPlanetRatio / max(dist, meshR + 1e-4), 0.0, 0.999));
+    float atm = max(meshAng - planetAng, 1e-5);
+    float h = clamp((pixelAng - planetAng) / atm, 0.0, 1.0);
+    if (uInner < 0.5) {
+      glow *= 1.0 - smoothstep(0.4, 0.88, h);
+    } else {
+      glow *= 1.0 - smoothstep(0.85, 0.98, h);
+    }
+
+    if (glow < 0.00008) {
       discard;
     }
 
@@ -89,26 +133,55 @@ const glowFragment = /* glsl */ `
   }
 `;
 
+const innerScaleFactor = (scale: number): number => 1 + (scale - 1) * 0.55;
+const outerScaleFactor = (scale: number): number => scale * OUTER_EXTEND;
+
+const powerFromHeight = (height: number, inner: boolean): number =>
+  inner
+    ? THREE.MathUtils.clamp(3.1 + (0.02 - height) * 40.0, 2.7, 5.5)
+    : THREE.MathUtils.clamp(2.4 + (0.02 - height) * 28.0, 2.0, 4.0);
+
+const writeUniforms = (
+  uniforms: THREE.ShaderMaterial["uniforms"],
+  params: AtmosphereGlowParams,
+  inner: boolean
+) => {
+  const sunset = params.mieColor ?? DEFAULT_MIE_COLOR;
+  const meshScale = inner
+    ? innerScaleFactor(params.scale)
+    : outerScaleFactor(params.scale);
+
+  uniforms.uColor.value.fromArray(params.color);
+  uniforms.uSunset.value.fromArray(sunset);
+  uniforms.uIntensity.value =
+    params.intensity * (inner ? INNER_INTENSITY : OUTER_INTENSITY);
+  uniforms.uPower.value = powerFromHeight(params.height, inner);
+  uniforms.uMieBoost.value = params.mie ?? 0.3;
+  uniforms.uScatter.value = THREE.MathUtils.clamp(params.scatter ?? 0, 0, 1);
+  uniforms.uPlanetRatio.value = 1 / Math.max(meshScale, 1e-4);
+};
+
 const makeMaterial = (
   params: AtmosphereGlowParams,
   inner: boolean
 ): THREE.ShaderMaterial => {
-  const sunset = params.mieColor ?? DEFAULT_MIE_COLOR;
-  const height = params.height;
-  const innerPower = THREE.MathUtils.clamp(3.1 + (0.02 - height) * 40.0, 2.7, 5.5);
-  const outerPower = THREE.MathUtils.clamp(2.4 + (0.02 - height) * 28.0, 2.0, 4.0);
-  const innerIntensity = params.intensity * 0.25;
-  const outerIntensity = params.intensity * 1.6;
+  const meshScale = inner
+    ? innerScaleFactor(params.scale)
+    : outerScaleFactor(params.scale);
 
   return new THREE.ShaderMaterial({
     uniforms: {
       uColor: { value: new THREE.Color().fromArray(params.color) },
-      uSunset: { value: new THREE.Color().fromArray(sunset) },
-      uIntensity: { value: inner ? innerIntensity : outerIntensity },
-      uPower: { value: inner ? innerPower : outerPower },
+      uSunset: {
+        value: new THREE.Color().fromArray(params.mieColor ?? DEFAULT_MIE_COLOR),
+      },
+      uIntensity: { value: 0 },
+      uPower: { value: 0 },
       uBias: { value: inner ? 0.0 : 0.63 },
       uInner: { value: inner ? 1 : 0 },
-      uMieBoost: { value: params.mie ?? 0.3 },
+      uMieBoost: { value: 0 },
+      uScatter: { value: 0 },
+      uPlanetRatio: { value: 1 / Math.max(meshScale, 1e-4) },
     },
     vertexShader: glowVertex,
     fragmentShader: glowFragment,
@@ -119,6 +192,27 @@ const makeMaterial = (
     depthTest: true,
     toneMapped: false,
   });
+};
+
+const glowMesh = (group: THREE.Group, name: string): THREE.Mesh => {
+  const mesh = group.getObjectByName(name);
+  if (!(mesh instanceof THREE.Mesh)) {
+    throw new Error(`Missing atmosphere glow mesh "${name}"`);
+  }
+  return mesh;
+};
+
+export const updateAtmosphereGlow = (
+  group: THREE.Group,
+  radius: number,
+  params: AtmosphereGlowParams
+) => {
+  const inner = glowMesh(group, "atmosphere-glow-inner");
+  const outer = glowMesh(group, "atmosphere-glow-outer");
+  writeUniforms((inner.material as THREE.ShaderMaterial).uniforms, params, true);
+  writeUniforms((outer.material as THREE.ShaderMaterial).uniforms, params, false);
+  inner.scale.setScalar(radius * innerScaleFactor(params.scale));
+  outer.scale.setScalar(radius * outerScaleFactor(params.scale));
 };
 
 const decorate = (mesh: THREE.Mesh, name: string): THREE.Mesh => {
@@ -142,16 +236,14 @@ export const createAtmosphereGlow = (
     new THREE.Mesh(getGeometry(), makeMaterial(params, true)),
     "atmosphere-glow-inner"
   );
-  inner.scale.setScalar(radius * (1 + (params.scale - 1) * 0.22));
-
   const outer = decorate(
     new THREE.Mesh(getGeometry(), makeMaterial(params, false)),
     "atmosphere-glow-outer"
   );
-  outer.scale.setScalar(radius * params.scale);
 
   group.add(inner, outer);
   group.raycast = () => {};
   group.userData.ignorePick = true;
+  updateAtmosphereGlow(group, radius, params);
   return group;
 };

--- a/src/setup/atmosphere-glow.ts
+++ b/src/setup/atmosphere-glow.ts
@@ -23,8 +23,8 @@ export interface AtmosphereGlowParams {
 export const DEFAULT_MIE_COLOR: [number, number, number] = [1.0, 0.78, 0.48];
 /** Extra outer radius so the fade to zero is not clipped by the mesh. */
 const OUTER_EXTEND = 1.06;
-const INNER_INTENSITY = 0.25;
-const OUTER_INTENSITY = 2.0;
+const INNER_INTENSITY = 0.7;
+const OUTER_INTENSITY = 1.35;
 
 let sharedGeometry: THREE.SphereGeometry | null = null;
 
@@ -65,6 +65,7 @@ const glowFragment = /* glsl */ `
   uniform float uMieBoost;
   uniform float uScatter;
   uniform float uPlanetRatio;
+  uniform float uHeight;
 
   varying vec3 vViewNormal;
   varying vec3 vWorldNormal;
@@ -108,10 +109,7 @@ const glowFragment = /* glsl */ `
     glow += rim * towardSun * uIntensity * (0.4 + uMieBoost * 1.15);
     glow *= mix(1.0, smoothstep(-0.7, -0.05, viewSun), uScatter);
 
-    // Apparent height: 0 at the planet disk, 1 at this shell's mesh.
-    // The outer mesh is larger than the visual atmosphere (OUTER_EXTEND) so
-    // we can fade to zero in that padding. Fading from the surface killed
-    // the whole visible ring — that ring is the only unoccluded outer glow.
+    // Apparent height: 0 against the planet, 1 at this shell's mesh.
     float dist = length(vCenterView);
     float meshR = length(vViewPos - vCenterView);
     float pixelAng = acos(clamp(dot(normalize(vViewPos), normalize(vCenterView)), -1.0, 1.0));
@@ -119,11 +117,15 @@ const glowFragment = /* glsl */ `
     float planetAng = asin(clamp(meshR * uPlanetRatio / max(dist, meshR + 1e-4), 0.0, 0.999));
     float atm = max(meshAng - planetAng, 1e-5);
     float h = clamp((pixelAng - planetAng) / atm, 0.0, 1.0);
-    if (uInner < 0.5) {
-      glow *= 1.0 - smoothstep(0.4, 0.88, h);
-    } else {
-      glow *= 1.0 - smoothstep(0.85, 0.98, h);
+
+    // Densest at the surface, thinning toward space. Small uHeight keeps
+    // a tight inner limb; larger values fade more slowly.
+    float falloff = mix(2.55, 0.85, clamp(uHeight / 0.09, 0.0, 1.0));
+    if (uInner > 0.5) {
+      falloff *= 0.7;
     }
+    glow *= pow(max(1.0 - h, 0.0), falloff);
+    glow *= 1.0 - smoothstep(0.84, 0.97, h);
 
     if (glow < 0.00008) {
       discard;
@@ -159,6 +161,7 @@ const writeUniforms = (
   uniforms.uMieBoost.value = params.mie ?? 0.3;
   uniforms.uScatter.value = THREE.MathUtils.clamp(params.scatter ?? 0, 0, 1);
   uniforms.uPlanetRatio.value = 1 / Math.max(meshScale, 1e-4);
+  uniforms.uHeight.value = Math.max(params.height, 0);
 };
 
 const makeMaterial = (
@@ -182,6 +185,7 @@ const makeMaterial = (
       uMieBoost: { value: 0 },
       uScatter: { value: 0 },
       uPlanetRatio: { value: 1 / Math.max(meshScale, 1e-4) },
+      uHeight: { value: 0 },
     },
     vertexShader: glowVertex,
     fragmentShader: glowFragment,

--- a/src/setup/bloom.ts
+++ b/src/setup/bloom.ts
@@ -42,6 +42,7 @@ const mixFragment = `
     float visible = step(viewZ, sunViewZ);
 
     gl_FragColor = base + bloom * visible;
+    #include <encodings_fragment>
   }
 `;
 

--- a/src/setup/dayside-relief.ts
+++ b/src/setup/dayside-relief.ts
@@ -1,0 +1,31 @@
+import * as THREE from "three";
+
+const NORMAL_MAPS = "#include <normal_fragment_maps>";
+
+// geometryNormal is the sphere. After bump/normal maps, `normal` can tilt
+// into the sun on the night side. Fade relief out as the geometric face
+// turns away from the sun (at the origin).
+const DAYSIDE_RELIEF = /* glsl */ `
+#include <normal_fragment_maps>
+vec3 sunDirView = normalize(viewMatrix[3].xyz + vViewPosition);
+float geoNL = dot(geometryNormal, sunDirView);
+normal = normalize(mix(geometryNormal, normal, smoothstep(0.0, 0.2, geoNL)));
+`;
+
+/**
+ * Keep bump/normal relief on the daylit hemisphere so crater walls cannot
+ * light up after the terminator.
+ */
+export const applyDaysideRelief = (material: THREE.MeshStandardMaterial) => {
+  const priorCompile = material.onBeforeCompile;
+  const priorKey = material.customProgramCacheKey.bind(material);
+
+  material.customProgramCacheKey = () => `${priorKey()}|dayside-relief`;
+  material.onBeforeCompile = (shader, renderer) => {
+    priorCompile.call(material, shader, renderer);
+    shader.fragmentShader = shader.fragmentShader.replace(
+      NORMAL_MAPS,
+      DAYSIDE_RELIEF
+    );
+  };
+};

--- a/src/setup/gui.ts
+++ b/src/setup/gui.ts
@@ -2,6 +2,8 @@ import * as dat from "lil-gui";
 import { LAYERS } from "../constants";
 import type { Lights } from "./lights";
 import { isIntroActive } from "./loading";
+import type { SolarSystem } from "./solar-system";
+import type { AtmosphereGlowParams } from "./atmosphere-glow";
 
 export const options = {
   showPaths: true,
@@ -10,40 +12,111 @@ export const options = {
   speed: 0.125,
 };
 
+const GLOW_BODIES = ["Mars", "Earth", "Venus", "Neptune"] as const;
+
+const roundGlow = (n: number): number => Number(n.toFixed(4));
+
+const glowJson = (params: AtmosphereGlowParams): string =>
+  JSON.stringify(
+    {
+      color: params.color.map(roundGlow),
+      mieColor: (params.mieColor ?? [1, 0.78, 0.48]).map(roundGlow),
+      intensity: roundGlow(params.intensity),
+      scale: roundGlow(params.scale),
+      height: roundGlow(params.height),
+      mie: roundGlow(params.mie ?? 0.3),
+      scatter: roundGlow(params.scatter ?? 0),
+    },
+    null,
+    2
+  );
+
+const addAtmosphereGlowControls = (gui: dat.GUI, solarSystem: SolarSystem) => {
+  const root = gui.addFolder("Atmosphere Glow");
+
+  for (const name of GLOW_BODIES) {
+    const body = solarSystem[name];
+    const params = body?.atmosphereGlowParams;
+    if (!body || !params) continue;
+
+    const folder = root.addFolder(name);
+    const apply = () => body.applyAtmosphereGlow();
+
+    folder.addColor(params, "color").name("Color").onChange(apply);
+    folder.addColor(params, "mieColor").name("Mie color").onChange(apply);
+    folder.add(params, "intensity", 0, 4, 0.01).name("Intensity").onChange(apply);
+    folder.add(params, "scale", 0, 1.2, 0.0005).name("Scale").onChange(apply);
+    folder.add(params, "height", 0, 0.5, 0.001).name("Height").onChange(apply);
+    folder.add(params, "mie", 0, 2, 0.01).name("Mie").onChange(apply);
+    folder.add(params, "scatter", 0, 1, 0.01).name("Scatter").onChange(apply);
+    folder
+      .add(
+        {
+          copyJson() {
+            void navigator.clipboard.writeText(glowJson(params));
+          },
+        },
+        "copyJson"
+      )
+      .name("Copy JSON");
+    folder.close();
+  }
+};
+
 export const createGUI = (
   clock: THREE.Clock,
   camera: THREE.Camera,
   lights: Lights,
+  solarSystem: SolarSystem,
   onRideSpin?: (ride: boolean) => void
 ) => {
   const gui = new dat.GUI();
 
   gui.title("Simulation Controls");
 
-  // Pause the simulation
-  gui
-    .add(options, "clock")
-    .name("Run")
-    .onChange((value: boolean) => {
-      if (value) {
-        clock.start();
-      } else {
-        clock.stop();
-      }
-    });
+  const setToggle = (button: HTMLElement, on: boolean) => {
+    button.setAttribute("aria-pressed", String(on));
+  };
 
-  // Control the simulation speed
+  const syncRunButton = (running: boolean) => {
+    const button = document.getElementById("btn-run");
+    if (!button) return;
+    setToggle(button, running);
+    button.setAttribute(
+      "aria-label",
+      running ? "Pause simulation" : "Play simulation"
+    );
+    const label = button.querySelector(".hud-ctrl-label");
+    if (label) {
+      label.textContent = running ? "Pause" : "Play";
+    }
+  };
+
+  const applyRunState = (running: boolean) => {
+    options.clock = running;
+    if (running) {
+      clock.start();
+    } else {
+      clock.stop();
+    }
+    syncRunButton(running);
+  };
+
   gui.add(options, "speed", 0, 5, 0.01).name("Speed");
 
   gui
     .add(lights.ambientLight, "intensity", 0, 1, 0.01)
     .name("Ambient");
 
+  addAtmosphereGlowControls(gui, solarSystem);
+
   gui.hide();
 
-  const setToggle = (button: HTMLElement, on: boolean) => {
-    button.setAttribute("aria-pressed", String(on));
-  };
+  const runButton = document.getElementById("btn-run");
+  runButton?.addEventListener("click", () => {
+    if (isIntroActive()) return;
+    applyRunState(!options.clock);
+  });
 
   const labelsButton = document.getElementById("btn-labels");
   labelsButton?.addEventListener("click", () => {
@@ -68,11 +141,16 @@ export const createGUI = (
   });
 
   const settingsButton = document.getElementById("btn-settings");
-  settingsButton?.addEventListener("click", () => {
-    if (isIntroActive()) return;
-    gui.show(gui._hidden);
-    setToggle(settingsButton, !gui._hidden);
-  });
+  if (!import.meta.env.DEV) {
+    settingsButton?.remove();
+  } else if (settingsButton) {
+    settingsButton.removeAttribute("hidden");
+    settingsButton.addEventListener("click", () => {
+      if (isIntroActive()) return;
+      gui.show(gui._hidden);
+      setToggle(settingsButton, !gui._hidden);
+    });
+  }
 
   return gui;
 };

--- a/src/setup/gui.ts
+++ b/src/setup/gui.ts
@@ -12,7 +12,7 @@ export const options = {
   speed: 0.125,
 };
 
-const GLOW_BODIES = ["Mars", "Earth", "Venus", "Neptune"] as const;
+const GLOW_BODIES = ["Jupiter", "Titan", "Saturn", "Uranus"] as const;
 
 const roundGlow = (n: number): number => Number(n.toFixed(4));
 

--- a/src/setup/height-normal.ts
+++ b/src/setup/height-normal.ts
@@ -1,0 +1,53 @@
+import * as THREE from "three";
+
+/** Oceans stay a little glossy; land stays matte. */
+const OCEAN_ROUGHNESS = 0.28;
+const LAND_ROUGHNESS = 1.0;
+
+const canvasFromImageData = (imageData: ImageData): HTMLCanvasElement => {
+  const canvas = document.createElement("canvas");
+  canvas.width = imageData.width;
+  canvas.height = imageData.height;
+  const ctx = canvas.getContext("2d");
+  if (!ctx) {
+    throw new Error("2D canvas is unavailable");
+  }
+  ctx.putImageData(imageData, 0, 0);
+  return canvas;
+};
+
+const imageDataFromTexture = (texture: THREE.Texture): ImageData => {
+  const image = texture.image as CanvasImageSource & { width: number; height: number };
+  const canvas = document.createElement("canvas");
+  canvas.width = image.width;
+  canvas.height = image.height;
+  const ctx = canvas.getContext("2d", { willReadFrequently: true });
+  if (!ctx) {
+    throw new Error("2D canvas is unavailable");
+  }
+  ctx.drawImage(image, 0, 0);
+  return ctx.getImageData(0, 0, canvas.width, canvas.height);
+};
+
+/**
+ * PlanetPixel-style specular (bright water) becomes a roughness map.
+ */
+export const applyGlossToRoughness = (texture: THREE.Texture) => {
+  const src = imageDataFromTexture(texture);
+  const { data } = src;
+  const span = LAND_ROUGHNESS - OCEAN_ROUGHNESS;
+
+  for (let i = 0; i < data.length; i += 4) {
+    const gloss = data[i] / 255;
+    const rough = (OCEAN_ROUGHNESS + span * (1 - gloss)) * 255;
+    data[i] = rough;
+    data[i + 1] = rough;
+    data[i + 2] = rough;
+  }
+
+  texture.image = canvasFromImageData(src);
+  texture.colorSpace = THREE.NoColorSpace;
+  texture.wrapS = THREE.RepeatWrapping;
+  texture.wrapT = THREE.ClampToEdgeWrapping;
+  texture.needsUpdate = true;
+};

--- a/src/setup/lights.ts
+++ b/src/setup/lights.ts
@@ -24,7 +24,7 @@ export type Lights = {
 };
 
 export const createLights = (): Lights => {
-  const ambientLight = new THREE.AmbientLight(0xffffff, 0.02);
+  const ambientLight = new THREE.AmbientLight(0xffffff, 0.025);
   ambientLight.layers.enable(0);
   ambientLight.layers.enable(LAYERS.SUN_SPOT);
 

--- a/src/setup/night-lights.ts
+++ b/src/setup/night-lights.ts
@@ -1,14 +1,14 @@
 import * as THREE from "three";
 
 const OUTGOING_LIGHT =
-  "vec3 outgoingLight = reflectedLight.directDiffuse + reflectedLight.indirectDiffuse + reflectedLight.directSpecular + reflectedLight.indirectSpecular + totalEmissiveRadiance;";
+  "vec3 outgoingLight = totalDiffuse + totalSpecular + totalEmissiveRadiance;";
 
-// Mix the night map over Phong lighting as N·L goes negative (the dark
+// Mix the night map over Standard lighting as N·L goes negative (the dark
 // hemisphere). Twilight is a soft band around the terminator so city lights
 // fade in rather than popping on. A luma gate boosts only the urban texels;
 // land and ocean stay at the darkened map values.
 const NIGHT_OUTGOING_LIGHT = /* glsl */ `
-vec3 dayLight = reflectedLight.directDiffuse + reflectedLight.indirectDiffuse + reflectedLight.directSpecular + reflectedLight.indirectSpecular;
+vec3 dayLight = totalDiffuse + totalSpecular;
 float nightLuma = max(totalEmissiveRadiance.r, max(totalEmissiveRadiance.g, totalEmissiveRadiance.b));
 totalEmissiveRadiance *= 1.0 + 1.0 * smoothstep(0.05, 0.25, nightLuma);
 #if ( NUM_SPOT_LIGHTS > 0 ) || ( NUM_POINT_LIGHTS > 0 )
@@ -25,18 +25,21 @@ totalEmissiveRadiance *= 1.0 + 1.0 * smoothstep(0.05, 0.25, nightLuma);
 `;
 
 /**
- * City lights on the night side. Uses the stock Phong program so bump and
- * specular stay intact; only the final lighting combine is patched.
+ * City lights on the night side. Uses the stock Standard program so normals
+ * and roughness stay intact; only the final lighting combine is patched.
  */
 export const applyNightLights = (
-  material: THREE.MeshPhongMaterial,
+  material: THREE.MeshStandardMaterial,
   nightMap: THREE.Texture
 ) => {
   material.emissive = new THREE.Color(1, 1, 1);
   material.emissiveMap = nightMap;
   material.emissiveIntensity = 1.0;
-  material.customProgramCacheKey = () => "night-lights";
-  material.onBeforeCompile = (shader) => {
+  const priorCompile = material.onBeforeCompile;
+  const priorKey = material.customProgramCacheKey.bind(material);
+  material.customProgramCacheKey = () => `${priorKey()}|night-lights`;
+  material.onBeforeCompile = (shader, renderer) => {
+    priorCompile.call(material, shader, renderer);
     shader.fragmentShader = shader.fragmentShader.replace(
       OUTGOING_LIGHT,
       NIGHT_OUTGOING_LIGHT

--- a/src/setup/planetary-object.ts
+++ b/src/setup/planetary-object.ts
@@ -3,6 +3,7 @@ import { createRingMesh, RING_OUTER } from "./rings";
 import { createPath } from "./path";
 import { loadTexture } from "./textures";
 import { applyNightLights } from "./night-lights";
+import { applyDaysideRelief } from "./dayside-relief";
 import {
   createAtmosphereGlow,
   type AtmosphereGlowParams,
@@ -81,7 +82,7 @@ export class PlanetaryObject {
   map!: THREE.Texture;
   bumpMap?: THREE.Texture;
   normalMap?: THREE.Texture;
-  specularMap?: THREE.Texture;
+  roughnessMap?: THREE.Texture;
   nightMap?: THREE.Texture;
   atmosphere: Atmosphere = {};
   atmosphereOpacity?: number;
@@ -147,13 +148,13 @@ export class PlanetaryObject {
   private loadTextures(textures: TexturePaths) {
     this.map = loadTexture(textures.map);
     if (textures.bump) {
-      this.bumpMap = loadTexture(textures.bump);
+      this.bumpMap = loadTexture(textures.bump, "data");
     }
     if (textures.normal) {
-      this.normalMap = loadTexture(textures.normal);
+      this.normalMap = loadTexture(textures.normal, "data");
     }
     if (textures.specular) {
-      this.specularMap = loadTexture(textures.specular);
+      this.roughnessMap = loadTexture(textures.specular, "glossRoughness");
     }
     if (textures.night) {
       this.nightMap = loadTexture(textures.night);
@@ -162,7 +163,7 @@ export class PlanetaryObject {
       this.atmosphere.map = loadTexture(textures.atmosphere);
     }
     if (textures.atmosphereAlpha) {
-      this.atmosphere.alpha = loadTexture(textures.atmosphereAlpha);
+      this.atmosphere.alpha = loadTexture(textures.atmosphereAlpha, "data");
     }
   }
 
@@ -184,15 +185,16 @@ export class PlanetaryObject {
         color: new THREE.Color(2.5, 2.5, 2.5),
       });
     } else {
-      material = new THREE.MeshPhongMaterial({
+      material = new THREE.MeshStandardMaterial({
         map: this.map,
-        shininess: 5,
+        roughness: this.roughnessMap ? 1 : 0.9,
+        metalness: 0,
         toneMapped: true,
       });
 
       if (this.bumpMap) {
         material.bumpMap = this.bumpMap;
-        material.bumpScale = this.radius / 50;
+        material.bumpScale = this.radius / 30;
       }
 
       if (this.normalMap) {
@@ -200,8 +202,12 @@ export class PlanetaryObject {
         material.normalScale.set(1.4, 1.4);
       }
 
-      if (this.specularMap) {
-        material.specularMap = this.specularMap;
+      if (this.roughnessMap) {
+        material.roughnessMap = this.roughnessMap;
+      }
+
+      if (this.bumpMap || this.normalMap) {
+        applyDaysideRelief(material);
       }
 
       if (this.nightMap) {
@@ -229,12 +235,13 @@ export class PlanetaryObject {
   private createAtmosphereMesh = () => {
     const geometry = new THREE.SphereGeometry(this.radius + 0.0005, 64, 64);
 
-    const material = new THREE.MeshPhongMaterial({
+    const material = new THREE.MeshStandardMaterial({
       map: this.atmosphere?.map,
       transparent: true,
       opacity: this.atmosphereOpacity ?? 1,
       depthWrite: false,
-      shininess: 0,
+      roughness: 1,
+      metalness: 0,
     });
 
     if (this.atmosphere.alpha) {

--- a/src/setup/planetary-object.ts
+++ b/src/setup/planetary-object.ts
@@ -6,6 +6,8 @@ import { applyNightLights } from "./night-lights";
 import { applyDaysideRelief } from "./dayside-relief";
 import {
   createAtmosphereGlow,
+  DEFAULT_MIE_COLOR,
+  updateAtmosphereGlow,
   type AtmosphereGlowParams,
 } from "./atmosphere-glow";
 import { Label } from "./label";
@@ -86,6 +88,8 @@ export class PlanetaryObject {
   nightMap?: THREE.Texture;
   atmosphere: Atmosphere = {};
   atmosphereOpacity?: number;
+  atmosphereGlow?: THREE.Group;
+  atmosphereGlowParams?: Required<AtmosphereGlowParams>;
   labels!: Label;
 
   constructor(body: Body, parent?: PlanetaryObject) {
@@ -121,7 +125,18 @@ export class PlanetaryObject {
     }
 
     if (body.atmosphereGlow) {
-      this.mesh.add(createAtmosphereGlow(this.radius, body.atmosphereGlow));
+      this.atmosphereGlowParams = {
+        ...body.atmosphereGlow,
+        color: [...body.atmosphereGlow.color],
+        mieColor: [...(body.atmosphereGlow.mieColor ?? DEFAULT_MIE_COLOR)],
+        mie: body.atmosphereGlow.mie ?? 0.3,
+        scatter: body.atmosphereGlow.scatter ?? 0,
+      };
+      this.atmosphereGlow = createAtmosphereGlow(
+        this.radius,
+        this.atmosphereGlowParams
+      );
+      this.mesh.add(this.atmosphereGlow);
     }
 
     this.initLabels(body.labels);
@@ -194,7 +209,7 @@ export class PlanetaryObject {
 
       if (this.bumpMap) {
         material.bumpMap = this.bumpMap;
-        material.bumpScale = this.radius / 30;
+        material.bumpScale = this.radius / 50;
       }
 
       if (this.normalMap) {
@@ -309,5 +324,14 @@ export class PlanetaryObject {
    */
   getMinDistance = (): number => {
     return this.radius * 1.8;
+  };
+
+  applyAtmosphereGlow = () => {
+    if (!this.atmosphereGlow || !this.atmosphereGlowParams) return;
+    updateAtmosphereGlow(
+      this.atmosphereGlow,
+      this.radius,
+      this.atmosphereGlowParams
+    );
   };
 }

--- a/src/setup/rings.ts
+++ b/src/setup/rings.ts
@@ -60,6 +60,8 @@ void main() {
   vec3 color = texel.rgb * diffuse * lit + texel.rgb * 0.045;
 
   gl_FragColor = vec4( color, texel.a );
+  #include <tonemapping_fragment>
+  #include <encodings_fragment>
 }
 `;
 

--- a/src/setup/starfield.ts
+++ b/src/setup/starfield.ts
@@ -35,6 +35,7 @@ export const createStarfield = (): THREE.Points => {
     opacity: 0.85,
     sizeAttenuation: false,
     depthWrite: false,
+    toneMapped: false,
   });
 
   const stars = new THREE.Points(geometry, material);

--- a/src/setup/textures.ts
+++ b/src/setup/textures.ts
@@ -1,19 +1,38 @@
 import * as THREE from "three";
 import { onLoaded, setLoadProgress } from "./loading";
+import { applyGlossToRoughness } from "./height-normal";
+
+export type TextureRole = "color" | "data" | "glossRoughness";
 
 let textureCount = 0;
 let texturesLoaded = 0;
 const textureLoader = new THREE.TextureLoader();
 
-export const loadTexture = (path: string) => {
-  return textureLoader.load(path, () => {
-    texturesLoaded++;
-    setLoadProgress((100 * texturesLoaded) / textureCount);
+const markLoaded = () => {
+  texturesLoaded++;
+  setLoadProgress((100 * texturesLoaded) / textureCount);
 
-    if (texturesLoaded === textureCount) {
-      onLoaded();
+  if (texturesLoaded === textureCount) {
+    onLoaded();
+  }
+};
+
+/**
+ * Color maps are sRGB albedo. Data maps (normals, bump, roughness, alpha)
+ * stay linear.
+ */
+export const loadTexture = (path: string, role: TextureRole = "color") => {
+  const texture = textureLoader.load(path, (loaded) => {
+    if (role === "glossRoughness") {
+      applyGlossToRoughness(loaded);
     }
+    markLoaded();
   });
+
+  texture.colorSpace =
+    role === "color" ? THREE.SRGBColorSpace : THREE.NoColorSpace;
+
+  return texture;
 };
 
 export const setTextureCount = (n: number) => {

--- a/src/styles/gui.scss
+++ b/src/styles/gui.scss
@@ -33,6 +33,10 @@
   pointer-events: none;
 }
 
+.hud-ctrl[hidden] {
+  display: none;
+}
+
 .hud-ctrl {
   appearance: none;
   box-sizing: border-box;
@@ -92,6 +96,18 @@
 .hud-ctrl-disc svg .is-fill {
   fill: currentColor;
   stroke: none;
+}
+
+.hud-ctrl .icon-play {
+  display: none;
+}
+
+.hud-ctrl[aria-pressed="false"] .icon-pause {
+  display: none;
+}
+
+.hud-ctrl[aria-pressed="false"] .icon-play {
+  display: block;
 }
 
 .hud-ctrl:hover .hud-ctrl-disc,

--- a/src/styles/loading-screen.scss
+++ b/src/styles/loading-screen.scss
@@ -30,7 +30,6 @@
   color: var(--text);
 }
 
-.intro-kicker,
 .intro-hint,
 .intro-load-row {
   font-size: 0.6875rem;
@@ -102,6 +101,7 @@
 }
 
 @keyframes intro-hint-pulse {
+
   0%,
   100% {
     opacity: 1;

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />


### PR DESCRIPTION
- Tune atmosphere colours and glow for Venus, Earth, Mars, Jupiter, Saturn, Uranus, Neptune, and Titan
- Fade limb haze so it is denser against the surface and thinner toward space
- Add live GUI controls for Jupiter, Titan, Saturn, and Uranus