### PR TITLE
Ambient light and Earth reflectivity

### DIFF
--- a/src/setup/height-normal.ts
+++ b/src/setup/height-normal.ts
@@ -1,8 +1,13 @@
 import * as THREE from "three";
 
-/** Oceans stay a little glossy; land stays matte. */
-const OCEAN_ROUGHNESS = 0.28;
+/** Oceans keep a soft sheen; land stays matte. */
+const OCEAN_ROUGHNESS = 0.55;
 const LAND_ROUGHNESS = 1.0;
+/** Point-light GGX still blows out water; scale the specular lobe. */
+const OCEAN_SPECULAR_SCALE = 0.12;
+
+const OUTGOING_LIGHT =
+  "vec3 outgoingLight = totalDiffuse + totalSpecular + totalEmissiveRadiance;";
 
 const canvasFromImageData = (imageData: ImageData): HTMLCanvasElement => {
   const canvas = document.createElement("canvas");
@@ -50,4 +55,26 @@ export const applyGlossToRoughness = (texture: THREE.Texture) => {
   texture.wrapS = THREE.RepeatWrapping;
   texture.wrapT = THREE.ClampToEdgeWrapping;
   texture.needsUpdate = true;
+};
+
+/**
+ * Dim the sun glint on glossy (ocean) texels only. Land stays at full
+ * Standard specular, which is already ~0 at roughness 1.
+ */
+export const applySoftOceanSpecular = (
+  material: THREE.MeshStandardMaterial
+) => {
+  const priorCompile = material.onBeforeCompile;
+  const priorKey = material.customProgramCacheKey.bind(material);
+  const oceanMask = `1.0 - smoothstep(${OCEAN_ROUGHNESS.toFixed(2)}, ${LAND_ROUGHNESS.toFixed(2)}, roughnessFactor)`;
+  const scaled = `totalSpecular *= mix(1.0, ${OCEAN_SPECULAR_SCALE.toFixed(2)}, ${oceanMask});`;
+
+  material.customProgramCacheKey = () => `${priorKey()}|soft-ocean-spec`;
+  material.onBeforeCompile = (shader, renderer) => {
+    priorCompile.call(material, shader, renderer);
+    shader.fragmentShader = shader.fragmentShader.replace(
+      OUTGOING_LIGHT,
+      `${scaled}\n${OUTGOING_LIGHT}`
+    );
+  };
 };

--- a/src/setup/lights.ts
+++ b/src/setup/lights.ts
@@ -24,7 +24,7 @@ export type Lights = {
 };
 
 export const createLights = (): Lights => {
-  const ambientLight = new THREE.AmbientLight(0xffffff, 0.025);
+  const ambientLight = new THREE.AmbientLight(0xffffff, 0.02);
   ambientLight.layers.enable(0);
   ambientLight.layers.enable(LAYERS.SUN_SPOT);
 


### PR DESCRIPTION
Soften Earth ocean glints and drop the scene ambient fill so the dayside reads with less wash.

- Raise ocean roughness so water is less mirror-like
- Lower ambient intensity slightly
- Add a shader helper to scale the GGX specular lobe on ocean texels only