### PR TITLE
Fix Moon and Venus orbit accuracy

### DIFF
--- a/src/planets.json
+++ b/src/planets.json
@@ -47,8 +47,8 @@
     "mass": 4.867e24,
     "distance": 108,
     "period": 224,
-    "daylength": 2802,
-    "cloudPeriod": 96,
+    "daylength": -5832.5,
+    "cloudPeriod": -96,
     "atmosphereOpacity": 0.9,
     "atmosphereGlow": {
       "color": [
@@ -70,6 +70,7 @@
     "type": "planet",
     "orbits": "Sun",
     "tilt": 2.64,
+    "inclination": 3.39,
     "traversable": true,
     "textures": {
       "map": "./textures/venus.jpg",
@@ -122,11 +123,13 @@
     "radius": 1737,
     "mass": 7.342e22,
     "distance": 0.38,
-    "period": 0,
-    "daylength": -28,
+    "period": 27.32,
+    "daylength": 655.7,
     "type": "moon",
     "orbits": "Earth",
-    "tilt": 5.8,
+    "tilt": 6.68,
+    "inclination": 5.14,
+    "equatorialOrbit": false,
     "traversable": true,
     "offset": -1.57,
     "textures": {

--- a/src/planets.json
+++ b/src/planets.json
@@ -48,7 +48,7 @@
     "distance": 108,
     "period": 224,
     "daylength": -5832.5,
-    "cloudPeriod": -96,
+    "cloudPeriod": 96,
     "atmosphereOpacity": 0.9,
     "atmosphereGlow": {
       "color": [

--- a/src/setup/body-info.ts
+++ b/src/setup/body-info.ts
@@ -147,6 +147,10 @@ const statsFor = (body: Body): Array<[string, string | Node]> => {
     rows.push(["Orbital period", formatPeriodDuration(body.period)]);
   }
 
+  if (body.inclination) {
+    rows.push(["Orbital inclination", formatTilt(body.inclination)]);
+  }
+
   if (body.type !== "moon" && body.type !== "star") {
     rows.push(["Day length", formatHours(body.daylength)]);
   }

--- a/src/setup/body-pick.ts
+++ b/src/setup/body-pick.ts
@@ -9,7 +9,7 @@ export const createBodyPicker = (
   const raycaster = new THREE.Raycaster();
   raycaster.layers.enableAll();
   const pointer = new THREE.Vector2();
-  const sun = solarSystem["Sun"].mesh;
+  const sun = solarSystem["Sun"].orbit;
 
   const pick = (clientX: number, clientY: number): string | null => {
     const rect = canvas.getBoundingClientRect();

--- a/src/setup/lights.ts
+++ b/src/setup/lights.ts
@@ -127,7 +127,7 @@ const forLocalMeshes = (
     }
   };
 
-  solarSystem[hostName].mesh.traverse(visitMesh);
+  solarSystem[hostName].origin.traverse(visitMesh);
 };
 
 const setSpotLit = (

--- a/src/setup/planetary-object.ts
+++ b/src/setup/planetary-object.ts
@@ -27,6 +27,14 @@ export interface Body {
   textures: TexturePaths;
   type: string;
   tilt: number;
+  /** Orbital inclination in degrees to the parent’s orbital plane. */
+  inclination?: number;
+  /**
+   * If true, this orbit is attached to the parent’s equator (tilted, not
+   * spinning). Moons and rings default to that; planets use the parent’s
+   * inertial frame so inclination is measured from the ecliptic.
+   */
+  equatorialOrbit?: boolean;
   orbits?: string;
   labels?: PointOfInterest[];
   description?: string;
@@ -76,7 +84,15 @@ export class PlanetaryObject {
   cloudPeriod?: number; // in hours
   orbits?: string;
   type: string;
-  tilt: number; // degrees
+  tilt: number; // radians
+  inclination: number; // radians
+  equatorialOrbit: boolean;
+  /** Inertial frame at the body centre. No axial tilt, no day spin. */
+  origin: THREE.Group;
+  /** Axial tilt only. Parent of the globe; moons/rings may attach here. */
+  equator: THREE.Group;
+  /** This body’s orbital plane (inclination). Parent of origin and path. */
+  orbit: THREE.Group;
   mesh: THREE.Mesh;
   atmosphereMesh?: THREE.Mesh;
   path?: THREE.Mesh;
@@ -105,6 +121,9 @@ export class PlanetaryObject {
     this.orbits = orbits;
     this.type = type;
     this.tilt = degreesToRadians(tilt);
+    this.inclination = degreesToRadians(body.inclination ?? 0);
+    this.equatorialOrbit =
+      body.equatorialOrbit ?? (type === "moon" || type === "ring");
     this.rng = body.offset ?? Math.random() * 2 * Math.PI;
 
     this.loadTextures(body.textures);
@@ -113,10 +132,27 @@ export class PlanetaryObject {
       throw new Error(`Ring "${body.name}" must be constructed with its parent`);
     }
 
+    this.orbit = new THREE.Group();
+    this.orbit.name = `${body.name}-orbit`;
+    this.orbit.rotation.x = this.inclination;
+
+    this.origin = new THREE.Group();
+    this.origin.name = `${body.name}-origin`;
+    this.orbit.add(this.origin);
+
+    this.equator = new THREE.Group();
+    this.equator.name = `${body.name}-equator`;
+    if (type !== "ring") {
+      this.equator.rotation.x = this.tilt;
+    }
+    this.origin.add(this.equator);
+
     this.mesh = this.createMesh(parent);
+    this.equator.add(this.mesh);
 
     if (this.orbits && this.distance > 0 && type !== "ring") {
       this.path = createPath(this.distance, this.radius, body.name);
+      this.orbit.add(this.path);
     }
 
     if (this.atmosphere.map) {
@@ -231,7 +267,6 @@ export class PlanetaryObject {
     }
 
     const sphere = new THREE.Mesh(geometry, material);
-    sphere.rotation.x = this.tilt;
     sphere.castShadow = true;
     sphere.receiveShadow = true;
 
@@ -275,7 +310,7 @@ export class PlanetaryObject {
   };
 
   private getOrbitRotation = (elapsedTime: number) => {
-    return this.daylength ? (elapsedTime * timeFactor) / (this.period * 24) : 0;
+    return this.period ? (elapsedTime * timeFactor) / (this.period * 24) : 0;
   };
 
   /**
@@ -288,9 +323,9 @@ export class PlanetaryObject {
     const orbitRotation = this.getOrbitRotation(elapsedTime);
     const orbit = orbitRotation + this.rng;
 
-    // Circular rotation around orbit.
-    this.mesh.position.x = Math.sin(orbit) * this.distance;
-    this.mesh.position.z = Math.cos(orbit) * this.distance;
+    // Move the inertial origin; the globe only spins in place.
+    this.origin.position.x = Math.sin(orbit) * this.distance;
+    this.origin.position.z = Math.cos(orbit) * this.distance;
     if (this.path) {
       this.path.rotation.y = orbit;
     }
@@ -313,7 +348,7 @@ export class PlanetaryObject {
    * Camera distance used when this body becomes the focus.
    */
   getFocusDistance = (): number => {
-    if (this.mesh.getObjectByName("rings")) {
+    if (this.origin.getObjectByName("rings")) {
       return this.radius * RING_OUTER * 1.55;
     }
     return this.radius * 2.25;

--- a/src/setup/solar-system.ts
+++ b/src/setup/solar-system.ts
@@ -1,10 +1,11 @@
+import type { Scene } from "three";
 import planetData from "../planets.json";
 import { Body, PlanetaryObject } from "./planetary-object";
 import { setTextureCount } from "./textures";
 
 export type SolarSystem = Record<string, PlanetaryObject>;
 
-export const createSolarSystem = (scene: THREE.Scene): SolarSystem => {
+export const createSolarSystem = (scene: Scene): SolarSystem => {
   const solarSystem: SolarSystem = {};
   let textureCount = 0;
 
@@ -12,10 +13,6 @@ export const createSolarSystem = (scene: THREE.Scene): SolarSystem => {
 
   for (const planet of planets) {
     const name = planet.name;
-
-    if (planet.period === 0 && planet.orbits) {
-      planet.period = planet.daylength / solarSystem[planet.orbits].daylength;
-    }
 
     const parent = planet.orbits ? solarSystem[planet.orbits] : undefined;
     const object = new PlanetaryObject(planet, parent);
@@ -27,15 +24,14 @@ export const createSolarSystem = (scene: THREE.Scene): SolarSystem => {
     textureCount += Object.keys(planet.textures).length;
 
     if (object.orbits) {
-      const parentMesh = solarSystem[object.orbits].mesh;
-      parentMesh.add(object.mesh);
-      if (object.path) {
-        parentMesh.add(object.path);
-      }
+      const host = solarSystem[object.orbits];
+      const parentFrame = object.equatorialOrbit ? host.equator : host.origin;
+      parentFrame.add(object.orbit);
+    } else {
+      scene.add(object.orbit);
     }
   }
 
-  scene.add(solarSystem["Sun"].mesh);
   setTextureCount(textureCount);
 
   return solarSystem;


### PR DESCRIPTION
Stop parent spin and tilt from dragging satellite paths, then correct the Moon and Venus orbits.

- Split each body into an inertial origin, equator, and spinning globe so orbits no longer inherit day length
- Moon: 27.32-day sidereal month, 5.14° inclination to the ecliptic, tidally locked rotation
- Venus: 3.39° orbital inclination and a 243-day retrograde spin
- Show orbital inclination on the HUD when it is set