### PR TITLE
Mobile nav and splash panel fixes

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -23,8 +23,10 @@
       <h1 id="intro-title">Solar System Model</h1>
       <p class="intro-body" id="intro-body">
         An interactive 3D model of the Sun, planets, and major moons, with orbits,
-        and points of interest. Double-click a planet to travel to
-        it.
+        and points of interest.
+      </p>
+      <p class="intro-body" id="intro-body-2">
+        Distances and sizes are NOT to scale.
       </p>
       <div class="intro-load">
         <div class="intro-load-row">
@@ -47,7 +49,7 @@
       <p class="identity-kicker" id="identity-kicker">Star</p>
       <h1 id="identity-title">Sun</h1>
     </header>
-    <aside id="body-info" class="body-info" role="complementary" aria-label="Body information">
+    <aside id="body-info" class="body-info" role="complementary" aria-label="Body information" hidden>
       <div class="body-info-toolbar">
         <button type="button" class="body-info-restore" id="body-info-restore" hidden>Info</button>
         <button type="button" class="body-info-minimise" id="body-info-minimise" aria-label="Minimise">−</button>
@@ -108,7 +110,8 @@
       </span>
       <span class="hud-ctrl-label">Spin</span>
     </button>
-    <button class="hud-ctrl" id="btn-settings" type="button" aria-label="Simulation controls" aria-pressed="false" hidden>
+    <button class="hud-ctrl" id="btn-settings" type="button" aria-label="Simulation controls" aria-pressed="false"
+      hidden>
       <span class="hud-ctrl-disc" aria-hidden="true">
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
           <circle cx="12" cy="12" r="3" />

--- a/src/setup/body-info.ts
+++ b/src/setup/body-info.ts
@@ -1,7 +1,7 @@
 import type { Body } from "./planetary-object";
 import type { PointOfInterest } from "./label";
 import planetData from "../planets.json";
-import { isIntroActive } from "./loading";
+import { isIntroActive, onIntroDismiss } from "./loading";
 import {
   formatDistance,
   formatHours,
@@ -27,6 +27,7 @@ const pipsEl = () => document.getElementById("body-info-pips");
 let canvasEl: HTMLElement | null = null;
 let orbitNavEl: HTMLElement | null = null;
 let minimised = false;
+let wantedOpen = false;
 let pipBodyName = "";
 let pipList: PointOfInterest[] = [];
 let onPoiPick: ((bodyName: string, poi: PointOfInterest) => void) | null = null;
@@ -91,14 +92,19 @@ const setMinimised = (next: boolean, moveFocus = false) => {
 };
 
 const setOpen = (open: boolean) => {
+  wantedOpen = open;
   const panel = panelEl();
   if (!panel) return;
-  panel.hidden = !open;
-  if (open) {
+  panel.hidden = !open || isIntroActive();
+  if (open && !isIntroActive()) {
     setMinimised(minimised);
   }
   syncPanelDock();
 };
+
+onIntroDismiss(() => {
+  if (wantedOpen) setOpen(true);
+});
 
 const closePanel = () => {
   setMinimised(false);

--- a/src/styles/loading-screen.scss
+++ b/src/styles/loading-screen.scss
@@ -120,6 +120,10 @@ body.intro-open {
   .orbit-nav {
     pointer-events: none;
   }
+
+  .body-info {
+    visibility: hidden;
+  }
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/src/styles/orbital-nav.scss
+++ b/src/styles/orbital-nav.scss
@@ -3,6 +3,9 @@
   --nav-ink: oklch(0.12 0.02 48);
   --nav-line: oklch(0.55 0.02 85 / 0.28);
   --nav-label: oklch(0.78 0.04 85);
+  --nav-body-min-height: 52px;
+  --nav-body-pad-top: 14px;
+  --nav-body-pad-bottom: 10px;
   --ease-out-quart: cubic-bezier(0.25, 1, 0.5, 1);
 
   position: absolute;
@@ -28,7 +31,11 @@
   position: absolute;
   left: 6%;
   right: 6%;
-  top: 28px;
+  top: calc(
+    var(--nav-body-pad-top) +
+      (var(--nav-body-min-height) - var(--nav-body-pad-top) - var(--nav-body-pad-bottom)) /
+      2
+  );
   height: 1px;
   background: var(--nav-line);
   pointer-events: none;
@@ -53,12 +60,13 @@
 
 .orbit-nav-body {
   position: relative;
+  box-sizing: border-box;
   display: flex;
   align-items: center;
   justify-content: center;
   width: 100%;
-  min-height: 52px;
-  padding: 14px 0 10px;
+  min-height: var(--nav-body-min-height);
+  padding: var(--nav-body-pad-top) 0 var(--nav-body-pad-bottom);
   background: transparent;
   border: none;
   cursor: pointer;
@@ -188,13 +196,11 @@
 
 @media (max-width: 560px) {
   .orbit-nav {
+    --nav-body-min-height: 44px;
+    --nav-body-pad-top: 12px;
+    --nav-body-pad-bottom: 8px;
     bottom: 12px;
     width: calc(100vw - 16px);
-  }
-
-  .orbit-nav-body {
-    min-height: 44px;
-    padding: 12px 0 8px;
   }
 
   .orbit-nav-label {

--- a/src/styles/orbital-nav.scss
+++ b/src/styles/orbital-nav.scss
@@ -31,11 +31,7 @@
   position: absolute;
   left: 6%;
   right: 6%;
-  top: calc(
-    var(--nav-body-pad-top) +
-      (var(--nav-body-min-height) - var(--nav-body-pad-top) - var(--nav-body-pad-bottom)) /
-      2
-  );
+  top: calc(var(--nav-body-pad-top) + (var(--nav-body-min-height) - var(--nav-body-pad-top) - var(--nav-body-pad-bottom)) / 2);
   height: 1px;
   background: var(--nav-line);
   pointer-events: none;
@@ -136,7 +132,7 @@
 .orbit-nav-label {
   position: absolute;
   left: 50%;
-  bottom: calc(100% - 12px);
+  bottom: calc(100% - 6px);
   transform: translateX(-50%);
   font-size: 0.6875rem;
   font-weight: 500;
@@ -190,6 +186,7 @@
 }
 
 .orbit-nav-body.is-moon .orbit-nav-label {
+  bottom: calc(100% - 10px);
   font-size: 0.625rem;
   letter-spacing: 0.06em;
 }
@@ -214,6 +211,7 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
+
   .orbit-nav-disc,
   .orbit-nav-label,
   .orbit-nav-moons {


### PR DESCRIPTION
- Align the orbit nav baseline with body padding so the line stays centered on smaller screens, and tighten planet label offset while moon labels keep a larger gap.
- Keep the body info panel hidden while the intro splash is open, and note that distances and sizes are not to scale.