### PR TITLE
Mobile zoom, info panel height, and HUD contrast

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -22,7 +22,7 @@
     <div class="intro-panel">
       <h1 id="intro-title">Solar System Model</h1>
       <p class="intro-body" id="intro-body">
-        An interactive 3D model of the Sun, planets, and major moons, with orbits,
+        An interactive 3D model of the Sun, planets, and major moons, with orbital mechanics,
         and points of interest.
       </p>
       <p class="intro-body" id="intro-body-2">

--- a/src/script.ts
+++ b/src/script.ts
@@ -65,9 +65,13 @@ window.addEventListener("resize", () => {
   sizes.width = window.innerWidth;
   sizes.height = window.innerHeight;
 
-  // Update camera
-  camera.aspect = sizes.width / sizes.height;
+  // Update cameras. OrbitControls drives fakeCamera; copy() would otherwise
+  // restore the aspect from when the clone was made.
+  const aspect = sizes.width / sizes.height;
+  camera.aspect = aspect;
   camera.updateProjectionMatrix();
+  fakeCamera.aspect = aspect;
+  fakeCamera.updateProjectionMatrix();
 
   // Update renderers
   renderer.setSize(sizes.width, sizes.height);

--- a/src/setup/focus-transition.ts
+++ b/src/setup/focus-transition.ts
@@ -445,7 +445,7 @@ export class FocusTransition {
    * and the mesh world matrix is current.
    */
   private writeDaysideDestination = (body: {
-    getFocusDistance: () => number;
+    getFocusDistance: (camera: THREE.PerspectiveCamera) => number;
     mesh: THREE.Object3D;
   }) => {
     this.solarSystem["Sun"].mesh.getWorldPosition(this.sunPos);
@@ -454,7 +454,7 @@ export class FocusTransition {
       .transformDirection(body.mesh.matrixWorld)
       .normalize();
     writeDaysideOffset(
-      body.getFocusDistance(),
+      body.getFocusDistance(this.camera),
       this.destLookAt,
       this.sunPos,
       this.poleDir,

--- a/src/setup/planetary-object.ts
+++ b/src/setup/planetary-object.ts
@@ -367,21 +367,30 @@ export class PlanetaryObject {
   };
 
   /**
-   * Camera distance from the body centre so the globe (or ring system)
-   * occupies `FOCUS_VIEWPORT_FILL` of the viewport width.
+   * Camera distance from the body centre. Uses the less zoomed-in of the
+   * 0.95-viewport-width fit and the previous fixed framing, so a traverse
+   * never comes in closer than before, but will pull back when the body
+   * would overflow the viewport.
    */
   getFocusDistance = (camera: THREE.PerspectiveCamera): number => {
-    return Math.max(
-      this.getMinDistance(),
-      distanceToFillViewport(this.getVisualRadius(), camera)
-    );
+    const fitted = distanceToFillViewport(this.getVisualRadius(), camera);
+    const legacy = this.getLegacyFocusDistance();
+    return Math.max(this.getMinDistance(), fitted, legacy);
+  };
+
+  /** Fixed framing used before viewport-width fitting. */
+  getLegacyFocusDistance = (): number => {
+    if (this.origin.getObjectByName("rings")) {
+      return this.radius * RING_OUTER * 1.55;
+    }
+    return this.radius * 2.25;
   };
 
   /**
    * @returns the minimum orbital control camera distance allowed.
    */
   getMinDistance = (): number => {
-    return this.radius * 1.2;
+    return this.radius * 1.8;
   };
 
   /** Bounding radius used when framing the body in the viewport. */

--- a/src/setup/planetary-object.ts
+++ b/src/setup/planetary-object.ts
@@ -76,6 +76,27 @@ const degreesToRadians = (degrees: number): number => {
   return (Math.PI * degrees) / 180;
 };
 
+/** Apparent diameter as a fraction of the viewport width on focus. */
+export const FOCUS_VIEWPORT_FILL = 0.95;
+
+/**
+ * Distance from a sphere’s centre so its silhouette spans `fill` of the
+ * viewport width. Uses NDC so the projected pixel width matches that fraction.
+ */
+export const distanceToFillViewport = (
+  radius: number,
+  camera: THREE.PerspectiveCamera,
+  fill = FOCUS_VIEWPORT_FILL
+): number => {
+  const tanVertical = Math.tan(THREE.MathUtils.degToRad(camera.fov * 0.5));
+  const tanHorizontal = tanVertical * Math.max(camera.aspect, 1e-6);
+  const tanLimb = fill * tanHorizontal;
+  if (tanLimb < 1e-6) {
+    return radius * 2.25;
+  }
+  return radius * Math.sqrt(1 + 1 / (tanLimb * tanLimb));
+};
+
 export class PlanetaryObject {
   radius: number; // in km
   distance: number; // in million km
@@ -271,7 +292,8 @@ export class PlanetaryObject {
     sphere.receiveShadow = true;
 
     if (this.type === "star") {
-      // Bloom pass only. Kept off layer 0 so the mix shader does not draw the Sun twice.
+      // Bloom pass only. Kept off layer 0 so the mix shader does not draw
+      // the Sun twice. Disk occlusion is handled in the bloom composite.
       sphere.layers.set(LAYERS.BLOOM);
     }
 
@@ -345,20 +367,29 @@ export class PlanetaryObject {
   };
 
   /**
-   * Camera distance used when this body becomes the focus.
+   * Camera distance from the body centre so the globe (or ring system)
+   * occupies `FOCUS_VIEWPORT_FILL` of the viewport width.
    */
-  getFocusDistance = (): number => {
-    if (this.origin.getObjectByName("rings")) {
-      return this.radius * RING_OUTER * 1.55;
-    }
-    return this.radius * 2.25;
+  getFocusDistance = (camera: THREE.PerspectiveCamera): number => {
+    return Math.max(
+      this.getMinDistance(),
+      distanceToFillViewport(this.getVisualRadius(), camera)
+    );
   };
 
   /**
    * @returns the minimum orbital control camera distance allowed.
    */
   getMinDistance = (): number => {
-    return this.radius * 1.8;
+    return this.radius * 1.2;
+  };
+
+  /** Bounding radius used when framing the body in the viewport. */
+  getVisualRadius = (): number => {
+    if (this.origin.getObjectByName("rings")) {
+      return this.radius * RING_OUTER;
+    }
+    return this.radius;
   };
 
   applyAtmosphereGlow = () => {

--- a/src/styles/body-info.scss
+++ b/src/styles/body-info.scss
@@ -19,7 +19,7 @@
   overflow-y: auto;
   pointer-events: auto;
   transform: translateY(-50%);
-  background: color-mix(in oklch, var(--bg-deep) 88%, transparent);
+  background: rgba(0, 0, 0, 0.9);
   border: 1px solid var(--line);
   font-family: var(--sans);
   color: var(--text);

--- a/src/styles/body-info.scss
+++ b/src/styles/body-info.scss
@@ -316,7 +316,7 @@
     right: 12px;
     width: auto;
     max-width: none;
-    max-height: min(40vh, calc(100dvh - var(--body-info-nav-offset, 8rem) - 6rem));
+    max-height: min(70vh, calc(100dvh - var(--body-info-nav-offset, 8rem) - 6rem));
     transform: none;
   }
 

--- a/src/styles/loading-screen.scss
+++ b/src/styles/loading-screen.scss
@@ -24,7 +24,7 @@
   transform: translate(-50%, -50%);
   width: min(30rem, calc(100vw - 40px));
   padding: 3rem;
-  background: color-mix(in oklch, var(--bg-deep) 88%, transparent);
+  background: rgba(0, 0, 0, 0.5);
   border: 1px solid var(--line);
   font-family: var(--sans);
   color: var(--text);


### PR DESCRIPTION
- Keep planet focus from overflowing the viewport on narrow screens, without zooming in closer than the previous framing.
- Fix camera aspect on resize so OrbitControls does not restore a stale projection after orientation or window changes.
- Raise the mobile info panel max height to 70vh so stats and POI copy fit without a scrollbar, and use stronger panel/splash backgrounds.