### PR TITLE
QoL: click to travel, starfield sprites, and dayside terminator

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ An interactive 3D model of the Sun, planets, and major moons. Travel between bod
 
 ## How to explore
 
-- Double-click a body to travel to it.
+- Click a body to travel to it.
 - Use the orbit nav to jump between the Sun, planets, and major moons.
 - **Labels** shows or hides points of interest. **Trails** shows or hides orbit paths. **Spin** rides the focused body's rotation. **Controls** opens simulation settings.
 - The info panel shows a short description and stats for the focused body.

--- a/src/planets.json
+++ b/src/planets.json
@@ -155,7 +155,7 @@
         "imageAlt": "Overhead view of Tycho Crater"
       }
     ],
-    "description": "Earth's only natural satellite, tidally locked so the same face always points home. Its dry, cratered surface still carries the marks of Apollo landings."
+    "description": "Earth's only natural satellite, tidally locked so the same face always points home. Its dry, cratered surface still carries the marks of the Apollo landings."
   },
   {
     "name": "Mars",

--- a/src/script.ts
+++ b/src/script.ts
@@ -263,6 +263,10 @@ const onHoverPick = (clientX: number, clientY: number) => {
   canvas.style.cursor = name ? "pointer" : "default";
 };
 
+const CLICK_DRAG_PX = 8;
+let pointerDownX = 0;
+let pointerDownY = 0;
+
 canvas.addEventListener("pointermove", (event) => {
   onHoverPick(event.clientX, event.clientY);
 });
@@ -271,8 +275,20 @@ canvas.addEventListener("pointerleave", () => {
   canvas.style.cursor = "default";
 });
 
-canvas.addEventListener("dblclick", (event) => {
+canvas.addEventListener("pointerdown", (event) => {
+  if (event.button !== 0) return;
+  pointerDownX = event.clientX;
+  pointerDownY = event.clientY;
+});
+
+canvas.addEventListener("click", (event) => {
   if (isIntroActive()) return;
+  if (Math.hypot(event.clientX - pointerDownX, event.clientY - pointerDownY) > CLICK_DRAG_PX) {
+    return;
+  }
+  if (poiProbe?.isHovering(event.clientX, event.clientY)) {
+    return;
+  }
   const name = picker.pick(event.clientX, event.clientY);
   if (name) {
     requestFocus(name);

--- a/src/setup/body-info.ts
+++ b/src/setup/body-info.ts
@@ -102,9 +102,35 @@ const setOpen = (open: boolean) => {
   syncPanelDock();
 };
 
-onIntroDismiss(() => {
-  if (wantedOpen) setOpen(true);
-});
+const prefersReducedMotion = () =>
+  window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+
+const revealAfterIntro = () => {
+  if (!wantedOpen) return;
+  const panel = panelEl();
+  const fade = panel !== null && !prefersReducedMotion();
+  if (panel && fade) {
+    panel.classList.add("is-entering");
+  }
+  setOpen(true);
+  if (!panel || !fade) return;
+
+  const finishEnter = () => {
+    panel.classList.remove("is-entering");
+    panel.removeEventListener("animationend", onEnterEnd);
+    window.clearTimeout(fallback);
+  };
+  const onEnterEnd = (event: AnimationEvent) => {
+    if (event.target !== panel || event.animationName !== "body-info-enter") {
+      return;
+    }
+    finishEnter();
+  };
+  const fallback = window.setTimeout(finishEnter, 400);
+  panel.addEventListener("animationend", onEnterEnd);
+};
+
+onIntroDismiss(revealAfterIntro);
 
 const closePanel = () => {
   setMinimised(false);

--- a/src/setup/focus-transition.ts
+++ b/src/setup/focus-transition.ts
@@ -8,8 +8,10 @@ const MIN_DIST = 1;
 const MAX_DIST = 25;
 /** Just off the Y pole so lookAt and OrbitControls keep a stable azimuth. */
 const OVERHEAD_POLAR = 0.02;
-/** South of the equator on the dayside arrival pose. */
-const DAYSIDE_LATITUDE_DEG = -2.5; // 2.5° north of the equator
+/** North of the equator on the dayside arrival pose. */
+const DAYSIDE_LATITUDE_DEG = 2.5; // 2.5° north of the equator
+/** Yaw off the Sun–planet line so a sliver of night sits on the left limb. */
+const DAYSIDE_LONGITUDE_DEG = 40;
 
 const easeInOut = (t: number): number => t * t * (3 - 2 * t);
 
@@ -52,9 +54,11 @@ const idleFrame = (): FocusFlightFrame => ({
   justFinished: false,
 });
 
+const daysideEast = new THREE.Vector3();
+
 /**
  * Camera offset from the body centre: sunward so the dayside faces the
- * lens, plus a slight drop along the pole.
+ * lens, a slight polar lift, and a yaw so night sits on the left limb.
  */
 const writeDaysideOffset = (
   distance: number,
@@ -69,10 +73,20 @@ const writeDaysideOffset = (
   } else {
     target.normalize();
   }
+  daysideEast.crossVectors(target, pole);
+  if (daysideEast.lengthSq() > 1e-10) {
+    daysideEast.normalize();
+  } else {
+    daysideEast.set(0, 0, 0);
+  }
   target.multiplyScalar(distance);
   target.addScaledVector(
     pole,
     -distance * Math.tan(THREE.MathUtils.degToRad(DAYSIDE_LATITUDE_DEG))
+  );
+  target.addScaledVector(
+    daysideEast,
+    distance * Math.tan(THREE.MathUtils.degToRad(DAYSIDE_LONGITUDE_DEG))
   );
 };
 

--- a/src/setup/loading.ts
+++ b/src/setup/loading.ts
@@ -88,14 +88,16 @@ const dismissIntro = () => {
   loadContainer.removeEventListener("click", dismissIntro);
   window.removeEventListener("keydown", onKeyDismiss);
 
+  // Unhide HUD during the overlay fade so the info panel can ease in with it.
+  document.body.classList.remove("intro-open");
+  for (const callback of dismissCallbacks) {
+    callback();
+  }
+  dismissCallbacks.length = 0;
+
   const finish = () => {
     loadContainer.hidden = true;
-    document.body.classList.remove("intro-open");
     setBackgroundInert(false);
-    for (const callback of dismissCallbacks) {
-      callback();
-    }
-    dismissCallbacks.length = 0;
   };
 
   if (prefersReducedMotion()) {

--- a/src/setup/starfield.ts
+++ b/src/setup/starfield.ts
@@ -1,7 +1,32 @@
 import * as THREE from "three";
 
-const STAR_COUNT = 2200;
+const STAR_COUNT = 2000;
 const DISTANCE = 400;
+
+const createStarSprite = (): THREE.CanvasTexture => {
+  const size = 64;
+  const canvas = document.createElement("canvas");
+  canvas.width = size;
+  canvas.height = size;
+  const ctx = canvas.getContext("2d");
+  if (!ctx) {
+    throw new Error("Could not create star sprite");
+  }
+
+  const center = size / 2;
+  const gradient = ctx.createRadialGradient(center, center, 0, center, center, center);
+  gradient.addColorStop(0, "rgba(255,255,255,1)");
+  gradient.addColorStop(0.18, "rgba(255,255,255,0.42)");
+  gradient.addColorStop(0.42, "rgba(255,255,255,0.1)");
+  gradient.addColorStop(1, "rgba(255,255,255,0)");
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, size, size);
+
+  const texture = new THREE.CanvasTexture(canvas);
+  texture.colorSpace = THREE.NoColorSpace;
+  texture.needsUpdate = true;
+  return texture;
+};
 
 export const createStarfield = (): THREE.Points => {
   const positions = new Float32Array(STAR_COUNT * 3);
@@ -18,7 +43,7 @@ export const createStarfield = (): THREE.Points => {
     positions[i * 3 + 1] = DISTANCE * Math.cos(theta);
     positions[i * 3 + 2] = DISTANCE * sinT * Math.sin(phi);
     mix.lerpColors(warm, cool, Math.random());
-    const mag = 0.35 + Math.random() * 0.65;
+    const mag = 0.18 + Math.random() * 0.38;
     colors[i * 3] = mix.r * mag;
     colors[i * 3 + 1] = mix.g * mag;
     colors[i * 3 + 2] = mix.b * mag;
@@ -29,10 +54,11 @@ export const createStarfield = (): THREE.Points => {
   geometry.setAttribute("color", new THREE.Float32BufferAttribute(colors, 3));
 
   const material = new THREE.PointsMaterial({
-    size: 1.6,
+    size: 4,
+    map: createStarSprite(),
     vertexColors: true,
     transparent: true,
-    opacity: 0.85,
+    opacity: 0.75,
     sizeAttenuation: false,
     depthWrite: false,
     toneMapped: false,

--- a/src/styles/body-info.scss
+++ b/src/styles/body-info.scss
@@ -27,6 +27,21 @@
   -webkit-font-smoothing: antialiased;
 }
 
+.body-info.is-entering {
+  opacity: 0;
+  animation: body-info-enter 250ms cubic-bezier(0.25, 1, 0.5, 1) forwards;
+}
+
+@keyframes body-info-enter {
+  from {
+    opacity: 0;
+  }
+
+  to {
+    opacity: 1;
+  }
+}
+
 .body-info-toolbar {
   position: absolute;
   top: 0.85rem;
@@ -270,6 +285,11 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
+  .body-info.is-entering {
+    opacity: 1;
+    animation: none;
+  }
+
   .body-info-pip::after {
     transition: none;
   }


### PR DESCRIPTION
- Travel to a body with a click instead of a double-click (ignore orbit drags and POI probe hits).
- Soften the starfield with a radial sprite, dimmer magnitudes, and slightly larger points.
- Yaw the dayside arrival pose off the Sun–planet line so a sliver of night sits on the left limb, keeping a small north-of-equator bias. Same pose on traverse end and URL restore.