### PR TITLE
Refactor planet data catalog

### DIFF
--- a/src/script.ts
+++ b/src/script.ts
@@ -330,7 +330,7 @@ fakeCamera.layers.enable(LAYERS.POILabel);
 fakeCamera.layers.enable(LAYERS.SUN_SPOT);
 
 // GUI
-const gui = createGUI(clock, fakeCamera, lights, solarSystem, (ride) => {
+const gui = createGUI(clock, fakeCamera, lights, (ride) => {
   poiForcedSpin = false;
   focusTransition.setRideSpin(ride, options.focus);
 });

--- a/src/setup/atmosphere-glow.ts
+++ b/src/setup/atmosphere-glow.ts
@@ -206,7 +206,7 @@ const glowMesh = (group: THREE.Group, name: string): THREE.Mesh => {
   return mesh;
 };
 
-export const updateAtmosphereGlow = (
+const updateAtmosphereGlow = (
   group: THREE.Group,
   radius: number,
   params: AtmosphereGlowParams

--- a/src/setup/body-info.ts
+++ b/src/setup/body-info.ts
@@ -1,6 +1,5 @@
-import type { Body } from "./planetary-object";
+import { getBody, type Body } from "./catalog";
 import type { PointOfInterest } from "./label";
-import planetData from "../planets.json";
 import { isIntroActive, onIntroDismiss } from "./loading";
 import {
   formatDistance,
@@ -11,7 +10,6 @@ import {
   formatTilt,
 } from "./format";
 
-const bodies = planetData as Body[];
 const DOCK_BOTTOM_QUERY = "(width < 1450px)";
 const NAV_GAP = 12;
 
@@ -266,7 +264,7 @@ const fillPips = (
 };
 
 export const updateBodyInfo = (name: string): void => {
-  const body = bodies.find((entry) => entry.name === name);
+  const body = getBody(name);
   if (!body || !body.traversable) return;
 
   const kicker = kickerEl();
@@ -287,7 +285,7 @@ export const updateBodyInfo = (name: string): void => {
 };
 
 export const updatePoiInfo = (bodyName: string, poi: PointOfInterest): void => {
-  const body = bodies.find((entry) => entry.name === bodyName);
+  const body = getBody(bodyName);
   if (!body || !body.traversable) return;
 
   const kicker = kickerEl();

--- a/src/setup/catalog.ts
+++ b/src/setup/catalog.ts
@@ -1,0 +1,87 @@
+import planetData from "../planets.json";
+import type { AtmosphereGlowParams } from "./atmosphere-glow";
+import type { PointOfInterest } from "./label";
+
+export type BodyType = "star" | "planet" | "moon" | "ring";
+
+export interface TexturePaths {
+  map: string;
+  bump?: string;
+  normal?: string;
+  atmosphere?: string;
+  atmosphereAlpha?: string;
+  specular?: string;
+  night?: string;
+}
+
+export interface Body {
+  name: string;
+  radius: number;
+  /** Mass in kilograms. Omitted for non-physical bodies such as rings. */
+  mass?: number;
+  distance: number;
+  period: number;
+  daylength: number;
+  /** Hours for one cloud-layer rotation. Faster than daylength so weather drifts. */
+  cloudPeriod?: number;
+  textures: TexturePaths;
+  type: BodyType;
+  tilt: number;
+  /** Orbital inclination in degrees to the parent’s orbital plane. */
+  inclination?: number;
+  /**
+   * If true, this orbit is attached to the parent’s equator (tilted, not
+   * spinning). Moons and rings default to that; planets use the parent’s
+   * inertial frame so inclination is measured from the ecliptic.
+   */
+  equatorialOrbit?: boolean;
+  orbits?: string;
+  labels?: PointOfInterest[];
+  description?: string;
+  traversable: boolean;
+  offset?: number;
+  stats?: Array<[string, string]>;
+  /** 0–1 opacity of the cloud-layer mesh. Defaults to 1. */
+  atmosphereOpacity?: number;
+  /** Limb haze for bodies with a visible atmosphere. */
+  atmosphereGlow?: AtmosphereGlowParams;
+}
+
+export const bodies: readonly Body[] = planetData as Body[];
+
+export const bodyByName: ReadonlyMap<string, Body> = new Map(
+  bodies.map((body) => [body.name, body])
+);
+
+export const getBody = (name: string): Body | undefined => bodyByName.get(name);
+
+export const traversableBodies: readonly Body[] = bodies.filter(
+  (body) => body.traversable
+);
+
+/** The Sun and planets, in order of heliocentric distance. */
+export const primaries: readonly Body[] = traversableBodies
+  .filter((body) => body.type === "star" || body.type === "planet")
+  .sort((a, b) => a.distance - b.distance);
+
+const moonLists = new Map<string, Body[]>();
+
+for (const body of traversableBodies) {
+  if (body.type !== "moon" || !body.orbits) continue;
+  const list = moonLists.get(body.orbits) ?? [];
+  list.push(body);
+  moonLists.set(body.orbits, list);
+}
+
+for (const list of moonLists.values()) {
+  list.sort((a, b) => Math.abs(a.distance) - Math.abs(b.distance));
+}
+
+export const moonsByParent: ReadonlyMap<string, readonly Body[]> = moonLists;
+
+/** Nav parent: a moon’s host planet, otherwise the body itself. */
+export const parentOf = (name: string): string => {
+  const body = bodyByName.get(name);
+  if (body?.type === "moon" && body.orbits) return body.orbits;
+  return name;
+};

--- a/src/setup/focus-transition.ts
+++ b/src/setup/focus-transition.ts
@@ -1,6 +1,7 @@
 import * as THREE from "three";
 import { OrbitControls } from "three/examples/jsm/controls/OrbitControls";
 import { SolarSystem } from "./solar-system";
+import type { BodyType } from "./catalog";
 
 const MIN_DURATION = 0.6;
 const MAX_DURATION = 4.0;
@@ -90,7 +91,8 @@ const writeDaysideOffset = (
   );
 };
 
-const isOverheadFocus = (body: { type: string }): boolean => body.type === "star";
+const isOverheadFocus = (body: { type: BodyType }): boolean =>
+  body.type === "star";
 
 const writeOverheadOffset = (
   maxDistance: number,

--- a/src/setup/focus-url.ts
+++ b/src/setup/focus-url.ts
@@ -1,12 +1,9 @@
-import planetData from "../planets.json";
-import type { Body } from "./planetary-object";
+import { traversableBodies } from "./catalog";
 
 const DEFAULT_TITLE = "Solar System Model";
 
 const bySlug = new Map(
-  (planetData as Body[])
-    .filter((body) => body.traversable)
-    .map((body) => [body.name.toLowerCase(), body.name])
+  traversableBodies.map((body) => [body.name.toLowerCase(), body.name])
 );
 
 const slugOf = (name: string): string => name.toLowerCase();

--- a/src/setup/format.ts
+++ b/src/setup/format.ts
@@ -47,6 +47,11 @@ export const formatPeriodDuration = (days: number): string => {
 
 export const formatHours = (hours: number): string => {
   const abs = Math.abs(hours);
+  if (abs > 240) {
+    const days = Math.round(abs / 24);
+    const unit = days === 1 ? "day" : "days";
+    return retrograde(`${days} ${unit}`, hours);
+  }
   const formatted = Number.isInteger(abs)
     ? abs.toLocaleString("en-GB")
     : abs.toLocaleString("en-GB", {

--- a/src/setup/gui.ts
+++ b/src/setup/gui.ts
@@ -2,8 +2,6 @@ import * as dat from "lil-gui";
 import { LAYERS } from "../constants";
 import type { Lights } from "./lights";
 import { isIntroActive } from "./loading";
-import type { SolarSystem } from "./solar-system";
-import type { AtmosphereGlowParams } from "./atmosphere-glow";
 
 export const options = {
   showPaths: true,
@@ -12,62 +10,10 @@ export const options = {
   speed: 0.125,
 };
 
-const GLOW_BODIES = ["Jupiter", "Titan", "Saturn", "Uranus"] as const;
-
-const roundGlow = (n: number): number => Number(n.toFixed(4));
-
-const glowJson = (params: AtmosphereGlowParams): string =>
-  JSON.stringify(
-    {
-      color: params.color.map(roundGlow),
-      mieColor: (params.mieColor ?? [1, 0.78, 0.48]).map(roundGlow),
-      intensity: roundGlow(params.intensity),
-      scale: roundGlow(params.scale),
-      height: roundGlow(params.height),
-      mie: roundGlow(params.mie ?? 0.3),
-      scatter: roundGlow(params.scatter ?? 0),
-    },
-    null,
-    2
-  );
-
-const addAtmosphereGlowControls = (gui: dat.GUI, solarSystem: SolarSystem) => {
-  const root = gui.addFolder("Atmosphere Glow");
-
-  for (const name of GLOW_BODIES) {
-    const body = solarSystem[name];
-    const params = body?.atmosphereGlowParams;
-    if (!body || !params) continue;
-
-    const folder = root.addFolder(name);
-    const apply = () => body.applyAtmosphereGlow();
-
-    folder.addColor(params, "color").name("Color").onChange(apply);
-    folder.addColor(params, "mieColor").name("Mie color").onChange(apply);
-    folder.add(params, "intensity", 0, 4, 0.01).name("Intensity").onChange(apply);
-    folder.add(params, "scale", 0, 1.2, 0.0005).name("Scale").onChange(apply);
-    folder.add(params, "height", 0, 0.5, 0.001).name("Height").onChange(apply);
-    folder.add(params, "mie", 0, 2, 0.01).name("Mie").onChange(apply);
-    folder.add(params, "scatter", 0, 1, 0.01).name("Scatter").onChange(apply);
-    folder
-      .add(
-        {
-          copyJson() {
-            void navigator.clipboard.writeText(glowJson(params));
-          },
-        },
-        "copyJson"
-      )
-      .name("Copy JSON");
-    folder.close();
-  }
-};
-
 export const createGUI = (
   clock: THREE.Clock,
   camera: THREE.Camera,
   lights: Lights,
-  solarSystem: SolarSystem,
   onRideSpin?: (ride: boolean) => void
 ) => {
   const gui = new dat.GUI();
@@ -107,8 +53,6 @@ export const createGUI = (
   gui
     .add(lights.ambientLight, "intensity", 0, 1, 0.01)
     .name("Ambient");
-
-  addAtmosphereGlowControls(gui, solarSystem);
 
   gui.hide();
 

--- a/src/setup/identity.ts
+++ b/src/setup/identity.ts
@@ -1,8 +1,5 @@
-import type { Body } from "./planetary-object";
+import { getBody } from "./catalog";
 import type { PointOfInterest } from "./label";
-import planetData from "../planets.json";
-
-const bodies = planetData as Body[];
 
 const kickerEl = () => document.getElementById("identity-kicker");
 const titleEl = () => document.getElementById("identity-title");
@@ -13,7 +10,7 @@ const poiTypeLabel = (type?: string): string => {
 };
 
 export const updateIdentity = (name: string, poi?: PointOfInterest): void => {
-  const body = bodies.find((entry) => entry.name === name);
+  const body = getBody(name);
   if (!body) return;
   const kicker = kickerEl();
   const title = titleEl();

--- a/src/setup/orbital-nav.ts
+++ b/src/setup/orbital-nav.ts
@@ -1,36 +1,6 @@
-import planetData from "../planets.json";
-import type { Body } from "./planetary-object";
+import { moonsByParent, parentOf, primaries, type Body } from "./catalog";
 import { isIntroActive } from "./loading";
 import { BODY_SWATCH, FALLBACK_SWATCH } from "./swatch";
-
-const bodies = planetData as Body[];
-
-const primaries: Body[] = bodies
-  .filter(
-    (body) => body.traversable && (body.type === "star" || body.type === "planet")
-  )
-  .sort((a, b) => a.distance - b.distance);
-
-const moonsByParent = new Map<string, Body[]>();
-
-for (const body of bodies) {
-  if (body.type !== "moon" || !body.traversable || !body.orbits) continue;
-  const list = moonsByParent.get(body.orbits) ?? [];
-  list.push(body);
-  moonsByParent.set(body.orbits, list);
-}
-
-for (const list of moonsByParent.values()) {
-  list.sort((a, b) => Math.abs(a.distance) - Math.abs(b.distance));
-}
-
-const bodyByName = new Map(bodies.map((body) => [body.name, body]));
-
-const parentOf = (name: string): string => {
-  const body = bodyByName.get(name);
-  if (body?.type === "moon" && body.orbits) return body.orbits;
-  return name;
-};
 
 const keyboardSequence = (focus: string): string[] => {
   const parent = parentOf(focus);

--- a/src/setup/planetary-object.ts
+++ b/src/setup/planetary-object.ts
@@ -4,56 +4,11 @@ import { createPath } from "./path";
 import { loadTexture } from "./textures";
 import { applyNightLights } from "./night-lights";
 import { applyDaysideRelief } from "./dayside-relief";
-import {
-  createAtmosphereGlow,
-  type AtmosphereGlowParams,
-} from "./atmosphere-glow";
+import { createAtmosphereGlow } from "./atmosphere-glow";
+import type { Body, BodyType, TexturePaths } from "./catalog";
 import { Label } from "./label";
 import { PointOfInterest } from "./label";
 import { LAYERS } from "../constants";
-
-export interface Body {
-  name: string;
-  radius: number;
-  /** Mass in kilograms. Omitted for non-physical bodies such as rings. */
-  mass?: number;
-  distance: number;
-  period: number;
-  daylength: number;
-  /** Hours for one cloud-layer rotation. Faster than daylength so weather drifts. */
-  cloudPeriod?: number;
-  textures: TexturePaths;
-  type: string;
-  tilt: number;
-  /** Orbital inclination in degrees to the parent’s orbital plane. */
-  inclination?: number;
-  /**
-   * If true, this orbit is attached to the parent’s equator (tilted, not
-   * spinning). Moons and rings default to that; planets use the parent’s
-   * inertial frame so inclination is measured from the ecliptic.
-   */
-  equatorialOrbit?: boolean;
-  orbits?: string;
-  labels?: PointOfInterest[];
-  description?: string;
-  traversable: boolean;
-  offset?: number;
-  stats?: Array<[string, string]>;
-  /** 0–1 opacity of the cloud-layer mesh. Defaults to 1. */
-  atmosphereOpacity?: number;
-  /** Limb haze for bodies with a visible atmosphere. */
-  atmosphereGlow?: AtmosphereGlowParams;
-}
-
-interface TexturePaths {
-  map: string;
-  bump?: string;
-  normal?: string;
-  atmosphere?: string;
-  atmosphereAlpha?: string;
-  specular?: string;
-  night?: string;
-}
 
 interface Atmosphere {
   map?: THREE.Texture;
@@ -102,7 +57,7 @@ export class PlanetaryObject {
   daylength: number; // in hours
   cloudPeriod?: number; // in hours
   orbits?: string;
-  type: string;
+  type: BodyType;
   tilt: number; // radians
   inclination: number; // radians
   equatorialOrbit: boolean;

--- a/src/setup/planetary-object.ts
+++ b/src/setup/planetary-object.ts
@@ -6,8 +6,6 @@ import { applyNightLights } from "./night-lights";
 import { applyDaysideRelief } from "./dayside-relief";
 import {
   createAtmosphereGlow,
-  DEFAULT_MIE_COLOR,
-  updateAtmosphereGlow,
   type AtmosphereGlowParams,
 } from "./atmosphere-glow";
 import { Label } from "./label";
@@ -125,8 +123,6 @@ export class PlanetaryObject {
   nightMap?: THREE.Texture;
   atmosphere: Atmosphere = {};
   atmosphereOpacity?: number;
-  atmosphereGlow?: THREE.Group;
-  atmosphereGlowParams?: Required<AtmosphereGlowParams>;
   labels!: Label;
 
   constructor(body: Body, parent?: PlanetaryObject) {
@@ -182,18 +178,7 @@ export class PlanetaryObject {
     }
 
     if (body.atmosphereGlow) {
-      this.atmosphereGlowParams = {
-        ...body.atmosphereGlow,
-        color: [...body.atmosphereGlow.color],
-        mieColor: [...(body.atmosphereGlow.mieColor ?? DEFAULT_MIE_COLOR)],
-        mie: body.atmosphereGlow.mie ?? 0.3,
-        scatter: body.atmosphereGlow.scatter ?? 0,
-      };
-      this.atmosphereGlow = createAtmosphereGlow(
-        this.radius,
-        this.atmosphereGlowParams
-      );
-      this.mesh.add(this.atmosphereGlow);
+      this.mesh.add(createAtmosphereGlow(this.radius, body.atmosphereGlow));
     }
 
     this.initLabels(body.labels);
@@ -399,14 +384,5 @@ export class PlanetaryObject {
       return this.radius * RING_OUTER;
     }
     return this.radius;
-  };
-
-  applyAtmosphereGlow = () => {
-    if (!this.atmosphereGlow || !this.atmosphereGlowParams) return;
-    updateAtmosphereGlow(
-      this.atmosphereGlow,
-      this.radius,
-      this.atmosphereGlowParams
-    );
   };
 }

--- a/src/setup/solar-system.ts
+++ b/src/setup/solar-system.ts
@@ -1,6 +1,6 @@
 import type { Scene } from "three";
-import planetData from "../planets.json";
-import { Body, PlanetaryObject } from "./planetary-object";
+import { bodies } from "./catalog";
+import { PlanetaryObject } from "./planetary-object";
 import { setTextureCount } from "./textures";
 
 export type SolarSystem = Record<string, PlanetaryObject>;
@@ -9,9 +9,7 @@ export const createSolarSystem = (scene: Scene): SolarSystem => {
   const solarSystem: SolarSystem = {};
   let textureCount = 0;
 
-  const planets: Body[] = (planetData as Body[]).map((planet) => ({ ...planet }));
-
-  for (const planet of planets) {
+  for (const planet of bodies) {
     const name = planet.name;
 
     const parent = planet.orbits ? solarSystem[planet.orbits] : undefined;


### PR DESCRIPTION
- Parse `planets.json` once in `catalog.ts` with a `BodyType` union. HUD, nav, URL slugs, and solar-system construction all read from that map instead of recasting the JSON.
- Remove unused atmosphere-glow GUI controls.
- Format day length in days when it is longer than 240 hours.