### PR TITLE
More realistic distances and sizes

### DIFF
--- a/src/script.ts
+++ b/src/script.ts
@@ -26,6 +26,11 @@ import {
   writeFocusToUrl,
 } from "./setup/focus-url";
 import { LAYERS } from "./constants";
+import {
+  applySceneScale,
+  outerOrbitRadius,
+  type ScaleState,
+} from "./setup/scale";
 import type { PointOfInterest } from "./setup/label";
 
 THREE.ColorManagement.enabled = true;
@@ -88,6 +93,13 @@ const urlFocus = readFocusFromUrl();
 if (urlFocus) {
   options.focus = urlFocus;
 }
+
+applySceneScale(solarSystem, {
+  radiusExponent: options.radiusExponent,
+  distanceExponent: options.distanceExponent,
+  focus: options.focus,
+  flight: null,
+});
 updateIdentity(options.focus);
 updateBodyInfo(options.focus);
 
@@ -120,6 +132,57 @@ const focusTransition = new FocusTransition(
   controls,
   solarSystem
 );
+
+const currentScaleState = (dt = 0): ScaleState => ({
+  radiusExponent: options.radiusExponent,
+  distanceExponent: options.distanceExponent,
+  focus: options.focus,
+  flight: focusTransition.travelScale(dt),
+});
+
+const fitCameraToScale = () => {
+  const extent = outerOrbitRadius(solarSystem);
+  const maxDistance = Math.max(MAX_CAMERA_DISTANCE, extent * 1.75);
+  const far = Math.max(1000, extent * 8);
+  controls.maxDistance = maxDistance;
+  if (camera.far !== far) {
+    camera.far = far;
+    fakeCamera.far = far;
+    camera.updateProjectionMatrix();
+    fakeCamera.updateProjectionMatrix();
+  }
+};
+
+fitCameraToScale();
+
+const framed = {
+  name: options.focus,
+  radius: solarSystem[options.focus].getVisualRadius(),
+};
+
+const keepFocusFraming = () => {
+  const body = solarSystem[options.focus];
+  const radius = body.getVisualRadius();
+  if (
+    options.focus !== framed.name ||
+    focusTransition.isActive() ||
+    body.type === "star"
+  ) {
+    framed.name = options.focus;
+    framed.radius = radius;
+    return;
+  }
+  if (framed.radius > 1e-8 && Math.abs(radius - framed.radius) > 1e-8) {
+    // Ride-spin parents the camera to the globe; mesh.scale already dollies.
+    if (camera.parent !== body.mesh) {
+      fakeCamera.position.multiplyScalar(radius / framed.radius);
+    }
+    controls.minDistance = body.getOrbitMinDistance(
+      camera.parent === body.mesh
+    );
+  }
+  framed.radius = radius;
+};
 
 const picker = createBodyPicker(camera, canvas, solarSystem);
 
@@ -344,6 +407,10 @@ poiProbe.sync();
 
   elapsedTime += clock.getDelta() * options.speed;
 
+  applySceneScale(solarSystem, currentScaleState(wallDt));
+  fitCameraToScale();
+  keepFocusFraming();
+
   // Update the solar system objects
   for (const object of Object.values(solarSystem)) {
     object.tick(elapsedTime);
@@ -376,6 +443,7 @@ poiProbe.sync();
 
   updateOrbitTrails(solarSystem, wallDt, {
     showAll: options.showPaths,
+    focus: options.focus,
     flying: frame.active && !frame.justFinished && frame.mode === "travel",
     from: frame.from,
     to: frame.to,

--- a/src/setup/focus-transition.ts
+++ b/src/setup/focus-transition.ts
@@ -2,6 +2,7 @@ import * as THREE from "three";
 import { OrbitControls } from "three/examples/jsm/controls/OrbitControls";
 import { SolarSystem } from "./solar-system";
 import type { BodyType } from "./catalog";
+import { localMoonOrbitRadius } from "./scale";
 
 const MIN_DURATION = 0.6;
 const MAX_DURATION = 4.0;
@@ -159,6 +160,23 @@ export class FocusTransition {
   destination = (): string | null => this.flight?.to ?? null;
 
   /**
+   * Current travel blend for scene scale. `progress` is 0 at takeoff, 1 at
+   * landing; pan flights do not change moon scale.
+   */
+  travelScale = (
+    dt = 0
+  ): { from: string; to: string; progress: number } | null => {
+    if (!this.flight || this.flight.mode !== "travel") {
+      return null;
+    }
+    return {
+      from: this.flight.from,
+      to: this.flight.to,
+      progress: Math.min(1, (this.flight.elapsed + dt) / this.flight.duration),
+    };
+  };
+
+  /**
    * Keep the camera beside the focused body as it orbits, without inheriting
    * axial spin. Call after bodies tick, while not flying.
    */
@@ -190,6 +208,7 @@ export class FocusTransition {
       return;
     }
     this.applyRig(focusName);
+    this.syncOrbitMinDistance(focusName);
   };
 
   begin = (from: string, to: string): boolean => {
@@ -232,7 +251,13 @@ export class FocusTransition {
     } else {
       this.writeDaysideDestination(toBody);
     }
-    const distance = this.startPos.distanceTo(this.destPos);
+    let distance = this.startPos.distanceTo(this.destPos);
+    if (toBody.type === "moon" && toBody.orbits) {
+      const parent = this.solarSystem[toBody.orbits];
+      if (parent) {
+        distance = Math.max(distance, localMoonOrbitRadius(toBody, parent));
+      }
+    }
 
     this.flight = {
       from: this.flight?.swapped ? this.flight.to : this.flight?.from ?? from,
@@ -446,9 +471,8 @@ export class FocusTransition {
       return;
     }
 
-    const toBody = this.solarSystem[this.flight.to];
-    this.controls.minDistance = toBody.getMinDistance();
     this.applyRig(this.flight.to);
+    this.syncOrbitMinDistance(this.flight.to);
     this.controls.enabled = true;
     this.controls.update();
     this.camera.copy(this.fakeCamera);
@@ -503,8 +527,8 @@ export class FocusTransition {
       this.camera.up.copy(this.poleDir);
     }
     this.camera.lookAt(this.worldTarget);
-    this.controls.minDistance = body.getMinDistance();
     this.applyRig(name);
+    this.syncOrbitMinDistance(name);
   };
 
   /**
@@ -531,6 +555,13 @@ export class FocusTransition {
     this.fakeCamera.up.set(0, 1, 0);
     this.camera.up.set(0, 1, 0);
     this.controls.target.set(0, 0, 0);
+  };
+
+  private syncOrbitMinDistance = (focusName: string) => {
+    const body = this.solarSystem[focusName];
+    this.controls.minDistance = body.getOrbitMinDistance(
+      this.camera.parent === body.mesh
+    );
   };
 
   /**

--- a/src/setup/focus-transition.ts
+++ b/src/setup/focus-transition.ts
@@ -15,7 +15,15 @@ const DAYSIDE_LATITUDE_DEG = 2.5; // 2.5° north of the equator
 /** Yaw off the Sun–planet line so a sliver of night sits on the left limb. */
 const DAYSIDE_LONGITUDE_DEG = 40;
 
+/** Surface pan: symmetric smoothstep. */
 const easeInOut = (t: number): number => t * t * (3 - 2 * t);
+
+/**
+ * Body-to-body travel. Quintic ease-in-out coasts into the destination
+ * more than smoothstep (zero first and second derivatives at both ends).
+ */
+const easeTravel = (t: number): number =>
+  t < 0.5 ? 16 * t ** 5 : 1 - (-2 * t + 2) ** 5 / 2;
 
 const durationFromDistance = (distance: number): number => {
   const t = Math.min(
@@ -375,7 +383,7 @@ export class FocusTransition {
 
     this.flight.elapsed += dt;
     const progress = Math.min(1, this.flight.elapsed / this.flight.duration);
-    const eased = easeInOut(progress);
+    const eased = easeTravel(progress);
 
     this.camera.position.lerpVectors(this.startPos, this.destPos, eased);
     this.currentLookAt.lerpVectors(this.startLookAt, this.destLookAt, eased);

--- a/src/setup/gui.ts
+++ b/src/setup/gui.ts
@@ -2,12 +2,18 @@ import * as dat from "lil-gui";
 import { LAYERS } from "../constants";
 import type { Lights } from "./lights";
 import { isIntroActive } from "./loading";
+import {
+  DEFAULT_DISTANCE_EXPONENT,
+  DEFAULT_RADIUS_EXPONENT,
+} from "./scale";
 
 export const options = {
   showPaths: true,
   focus: "Sun",
   clock: true,
   speed: 0.125,
+  radiusExponent: DEFAULT_RADIUS_EXPONENT,
+  distanceExponent: DEFAULT_DISTANCE_EXPONENT,
 };
 
 export const createGUI = (
@@ -49,6 +55,13 @@ export const createGUI = (
   };
 
   gui.add(options, "speed", 0, 5, 0.01).name("Speed");
+
+  gui
+    .add(options, "radiusExponent", DEFAULT_RADIUS_EXPONENT, 1, 0.01)
+    .name("Size exponent");
+  gui
+    .add(options, "distanceExponent", 0.2, 1, 0.01)
+    .name("Distance exponent");
 
   gui
     .add(lights.ambientLight, "intensity", 0, 1, 0.01)

--- a/src/setup/orbit-trails.ts
+++ b/src/setup/orbit-trails.ts
@@ -20,19 +20,48 @@ const hostOf = (name: string, solarSystem: SolarSystem): string => {
   return name;
 };
 
-const addFlightBody = (
+const isOverviewFocus = (name: string, solarSystem: SolarSystem): boolean => {
+  const body = solarSystem[name];
+  return !body || body.type === "star";
+};
+
+/** Planet plus its moons, or a moon’s parent plus siblings. */
+const addSystem = (
   lit: Set<string>,
   name: string,
   solarSystem: SolarSystem
 ) => {
-  if (!name || !solarSystem[name]?.path) {
+  if (!name) {
     return;
   }
-  lit.add(name);
   const host = hostOf(name, solarSystem);
-  if (host !== name && solarSystem[host]?.path) {
+  if (solarSystem[host]?.path) {
     lit.add(host);
   }
+  for (const [bodyName, body] of Object.entries(solarSystem)) {
+    if (body.type === "moon" && body.orbits === host && body.path) {
+      lit.add(bodyName);
+    }
+  }
+};
+
+const inFocusedSystem = (
+  name: string,
+  solarSystem: SolarSystem,
+  focus: string
+): boolean => {
+  if (isOverviewFocus(focus, solarSystem)) {
+    return true;
+  }
+  const host = hostOf(focus, solarSystem);
+  const body = solarSystem[name];
+  if (body.type === "planet") {
+    return name === host;
+  }
+  if (body.type === "moon") {
+    return body.orbits === host;
+  }
+  return false;
 };
 
 export const updateOrbitTrails = (
@@ -40,6 +69,7 @@ export const updateOrbitTrails = (
   dt: number,
   state: {
     showAll: boolean;
+    focus: string;
     flying: boolean;
     from: string;
     to: string;
@@ -60,12 +90,12 @@ export const updateOrbitTrails = (
 
   const lit = new Set<string>();
   if (state.flying) {
-    addFlightBody(lit, state.from, solarSystem);
-    addFlightBody(lit, state.to, solarSystem);
+    addSystem(lit, state.from, solarSystem);
+    addSystem(lit, state.to, solarSystem);
   } else if (lingerLeft > 0) {
-    addFlightBody(lit, lingerTo, solarSystem);
+    addSystem(lit, lingerTo, solarSystem);
     if (lingerLeft > LINGER * 0.45) {
-      addFlightBody(lit, lingerFrom, solarSystem);
+      addSystem(lit, lingerFrom, solarSystem);
     }
   }
 
@@ -77,11 +107,12 @@ export const updateOrbitTrails = (
     }
 
     let target = 0;
-    if (state.showAll && object.type === "planet") {
-      target = TOGGLE_PLANET;
-    }
-    if (state.showAll && object.type === "moon") {
-      target = TOGGLE_MOON;
+    if (state.showAll && inFocusedSystem(name, solarSystem, state.focus)) {
+      if (object.type === "planet") {
+        target = TOGGLE_PLANET;
+      } else if (object.type === "moon") {
+        target = TOGGLE_MOON;
+      }
     }
     if (lit.has(name)) {
       target = Math.max(target, FLIGHT);

--- a/src/setup/path.ts
+++ b/src/setup/path.ts
@@ -70,6 +70,8 @@ export const createPath = (
   mesh.frustumCulled = false;
   mesh.userData.ignorePick = true;
   mesh.userData.trailOpacity = 0;
+  mesh.userData.pathOrbit = orbitRadius;
+  mesh.userData.pathBody = bodyRadius;
   mesh.renderOrder = 2;
   return mesh;
 };
@@ -79,4 +81,32 @@ export const setTrailOpacity = (trail: THREE.Mesh, opacity: number) => {
   material.opacity = opacity;
   trail.userData.trailOpacity = opacity;
   trail.visible = opacity > 0.01;
+};
+
+export const updatePath = (
+  trail: THREE.Mesh,
+  orbitRadius: number,
+  bodyRadius: number,
+  name: string
+) => {
+  const prevOrbit = trail.userData.pathOrbit as number | undefined;
+  const prevBody = trail.userData.pathBody as number | undefined;
+  if (
+    prevOrbit !== undefined &&
+    prevBody !== undefined &&
+    Math.abs(prevOrbit - orbitRadius) < 1e-8 &&
+    Math.abs(prevBody - bodyRadius) < 1e-8
+  ) {
+    return;
+  }
+
+  const old = trail.geometry;
+  trail.geometry = createTrailGeometry(
+    orbitRadius,
+    bodyRadius,
+    bodyColorThree(name)
+  );
+  old.dispose();
+  trail.userData.pathOrbit = orbitRadius;
+  trail.userData.pathBody = bodyRadius;
 };

--- a/src/setup/planetary-object.ts
+++ b/src/setup/planetary-object.ts
@@ -1,6 +1,6 @@
 import * as THREE from "three";
-import { createRingMesh, RING_OUTER } from "./rings";
-import { createPath } from "./path";
+import { createRingMesh, RING_OUTER, setRingPlanetRadius } from "./rings";
+import { createPath, updatePath } from "./path";
 import { loadTexture } from "./textures";
 import { applyNightLights } from "./night-lights";
 import { applyDaysideRelief } from "./dayside-relief";
@@ -9,6 +9,12 @@ import type { Body, BodyType, TexturePaths } from "./catalog";
 import { Label } from "./label";
 import { PointOfInterest } from "./label";
 import { LAYERS } from "../constants";
+import {
+  DEFAULT_DISTANCE_EXPONENT,
+  DEFAULT_RADIUS_EXPONENT,
+  overviewDistance,
+  overviewRadius,
+} from "./scale";
 
 interface Atmosphere {
   map?: THREE.Texture;
@@ -16,14 +22,6 @@ interface Atmosphere {
 }
 
 const timeFactor = 8 * Math.PI * 2; // 1s real-time => 8h simulation time
-
-const normaliseRadius = (radius: number): number => {
-  return Math.sqrt(radius) / 500;
-};
-
-const normaliseDistance = (distance: number): number => {
-  return Math.pow(distance, 0.4);
-};
 
 const degreesToRadians = (degrees: number): number => {
   return (Math.PI * degrees) / 180;
@@ -51,8 +49,18 @@ export const distanceToFillViewport = (
 };
 
 export class PlanetaryObject {
-  radius: number; // in km
-  distance: number; // in million km
+  name: string;
+  /** Catalog radius in km. */
+  catalogRadius: number;
+  /** Catalog orbital distance in million km. */
+  catalogDistance: number;
+  /** Current scene-space globe radius. */
+  radius: number;
+  /** Current scene-space orbital radius. */
+  distance: number;
+  /** Sphere geometry radius; mesh.scale maps this to `radius`. */
+  readonly meshLocalRadius: number;
+  private readonly ringSourceRadius: number;
   period: number; // in days
   daylength: number; // in hours
   cloudPeriod?: number; // in hours
@@ -84,8 +92,13 @@ export class PlanetaryObject {
     const { radius, distance, period, daylength, cloudPeriod, orbits, type, tilt } =
       body;
 
-    this.radius = normaliseRadius(radius);
-    this.distance = normaliseDistance(distance);
+    this.name = body.name;
+    this.catalogRadius = radius;
+    this.catalogDistance = distance;
+    this.radius = overviewRadius(radius, DEFAULT_RADIUS_EXPONENT);
+    this.distance = overviewDistance(distance, DEFAULT_DISTANCE_EXPONENT);
+    this.meshLocalRadius = this.radius;
+    this.ringSourceRadius = type === "ring" && parent ? parent.radius : 0;
     this.period = period;
     this.daylength = daylength;
     this.cloudPeriod = cloudPeriod;
@@ -138,6 +151,37 @@ export class PlanetaryObject {
 
     this.initLabels(body.labels);
   }
+
+  /**
+   * Resize the globe and orbit to the current scene scale. Geometry stays
+   * at `meshLocalRadius`; uniform mesh scale carries the rest.
+   */
+  setSceneSize = (radius: number, distance: number) => {
+    const radiusChanged = Math.abs(this.radius - radius) > 1e-10;
+    const distanceChanged = Math.abs(this.distance - distance) > 1e-10;
+    if (!radiusChanged && !distanceChanged) {
+      return;
+    }
+    this.radius = radius;
+    this.distance = distance;
+    if (this.type === "ring") {
+      return;
+    }
+    if (radiusChanged && this.meshLocalRadius > 0) {
+      this.mesh.scale.setScalar(radius / this.meshLocalRadius);
+    }
+    if (this.path) {
+      updatePath(this.path, this.distance, this.radius, this.name);
+    }
+  };
+
+  /** Keep the ring disk outside the parent globe as that globe's scene size changes. */
+  setRingScale = (parentRadius: number) => {
+    if (this.type !== "ring") {
+      return;
+    }
+    setRingPlanetRadius(this.mesh, parentRadius, this.ringSourceRadius);
+  };
 
   /**
    * Creates label objects for each point-of-interest.
@@ -331,6 +375,17 @@ export class PlanetaryObject {
    */
   getMinDistance = (): number => {
     return this.radius * 1.8;
+  };
+
+  /**
+   * OrbitControls min distance in the camera parent's local units. Ride-spin
+   * parents to the mesh, so the limit must be in geometry space, not scene space.
+   */
+  getOrbitMinDistance = (parentedToMesh: boolean): number => {
+    if (parentedToMesh && this.meshLocalRadius > 0) {
+      return this.meshLocalRadius * 1.8;
+    }
+    return this.getMinDistance();
   };
 
   /** Bounding radius used when framing the body in the viewport. */

--- a/src/setup/poi-probe.ts
+++ b/src/setup/poi-probe.ts
@@ -137,9 +137,9 @@ export const createPoiProbe = (
     }
 
     attachTo(object);
-    group.scale.setScalar(object.radius);
+    group.scale.setScalar(object.meshLocalRadius);
     poiLocalPosition(
-      object.radius * SURFACE_LIFT,
+      object.meshLocalRadius * SURFACE_LIFT,
       state.y,
       state.z,
       group.position

--- a/src/setup/rings.ts
+++ b/src/setup/rings.ts
@@ -115,3 +115,16 @@ export const createRingMesh = (
 
   return rings;
 };
+
+export const setRingPlanetRadius = (
+  mesh: THREE.Mesh,
+  planetRadius: number,
+  sourceRadius: number
+) => {
+  if (sourceRadius <= 0) {
+    return;
+  }
+  mesh.scale.setScalar(planetRadius / sourceRadius);
+  const material = mesh.material as THREE.ShaderMaterial;
+  material.uniforms.uPlanetRadius.value = planetRadius;
+};

--- a/src/setup/scale.ts
+++ b/src/setup/scale.ts
@@ -1,0 +1,198 @@
+import { getBody, parentOf } from "./catalog";
+import type { SolarSystem } from "./solar-system";
+import type { PlanetaryObject } from "./planetary-object";
+
+/** Matches the original `sqrt(radius)` compression. 1 is linear in km. */
+export const DEFAULT_RADIUS_EXPONENT = 0.5;
+/** Matches the original `distance^0.4` compression. 1 is linear in million km. */
+export const DEFAULT_DISTANCE_EXPONENT = 0.75;
+
+const earth = getBody("Earth");
+if (!earth) {
+  throw new Error("Earth catalog entry required for scene scale");
+}
+
+const EARTH_RADIUS_KM = earth.radius;
+const EARTH_DISTANCE_MKM = earth.distance;
+
+/** Scene radius of Earth at the default size exponent. Anchors the slider. */
+const EARTH_SCENE_RADIUS =
+  Math.pow(EARTH_RADIUS_KM, DEFAULT_RADIUS_EXPONENT) / 500;
+/** Scene orbit radius of Earth at the default distance exponent. */
+const EARTH_SCENE_DISTANCE = Math.pow(
+  EARTH_DISTANCE_MKM,
+  DEFAULT_DISTANCE_EXPONENT
+);
+
+const lerp = (a: number, b: number, t: number): number => a + (b - a) * t;
+const smoothstep = (t: number): number => t * t * (3 - 2 * t);
+
+export type ScaleFlight = {
+  from: string;
+  to: string;
+  progress: number;
+};
+
+export type ScaleState = {
+  radiusExponent: number;
+  distanceExponent: number;
+  focus: string;
+  flight: ScaleFlight | null;
+};
+
+/**
+ * Overview globe size. Earth keeps a constant scene radius so the exponent
+ * changes relative proportions, not the whole system's on-screen scale.
+ */
+export const overviewRadius = (
+  radiusKm: number,
+  exponent: number
+): number => {
+  if (radiusKm <= 0) {
+    return 0;
+  }
+  return Math.pow(radiusKm / EARTH_RADIUS_KM, exponent) * EARTH_SCENE_RADIUS;
+};
+
+/**
+ * Overview orbit radius. Earth's heliocentric distance stays constant so
+ * raising the exponent spreads (or packs) the other orbits around it.
+ */
+export const overviewDistance = (
+  distanceMkm: number,
+  exponent: number
+): number => {
+  if (distanceMkm <= 0) {
+    return 0;
+  }
+  return (
+    Math.pow(distanceMkm / EARTH_DISTANCE_MKM, exponent) * EARTH_SCENE_DISTANCE
+  );
+};
+
+/** True size relative to a parent whose scene radius is already known. */
+export const localRadius = (
+  radiusKm: number,
+  parentRadiusKm: number,
+  parentSceneRadius: number
+): number => {
+  if (parentRadiusKm <= 0) {
+    return 0;
+  }
+  return (radiusKm / parentRadiusKm) * parentSceneRadius;
+};
+
+/**
+ * Focused moon orbit as a power of true parent-radii distance. 1 would be
+ * linear (Moon at ~60 Earth radii); 0.75 keeps the order of magnitude
+ * without the full empty gap.
+ */
+const LOCAL_MOON_DISTANCE_EXPONENT = 0.75;
+
+export const localDistance = (
+  distanceMkm: number,
+  parentRadiusKm: number,
+  parentSceneRadius: number
+): number => {
+  if (parentRadiusKm <= 0) {
+    return 0;
+  }
+  const parentRadii = (distanceMkm * 1_000_000) / parentRadiusKm;
+  return Math.pow(parentRadii, LOCAL_MOON_DISTANCE_EXPONENT) * parentSceneRadius;
+};
+
+export const localMoonOrbitRadius = (
+  moon: PlanetaryObject,
+  parent: PlanetaryObject
+): number =>
+  localDistance(moon.catalogDistance, parent.catalogRadius, parent.radius);
+
+const moonLocalWeight = (
+  moon: PlanetaryObject,
+  state: ScaleState
+): number => {
+  if (moon.type !== "moon" || !moon.orbits) {
+    return 0;
+  }
+
+  const host = moon.orbits;
+  const fromHost = parentOf(state.flight?.from ?? state.focus);
+  const toHost = parentOf(state.flight?.to ?? state.focus);
+  const weightFor = (name: string): number =>
+    name !== "Sun" && name === host ? 1 : 0;
+
+  const fromWeight = weightFor(fromHost);
+  const toWeight = weightFor(toHost);
+  if (!state.flight || fromWeight === toWeight) {
+    return toWeight;
+  }
+
+  return lerp(fromWeight, toWeight, smoothstep(state.flight.progress));
+};
+
+const sceneSize = (
+  body: PlanetaryObject,
+  parent: PlanetaryObject | undefined,
+  state: ScaleState
+): { radius: number; distance: number } => {
+  const overviewR = overviewRadius(body.catalogRadius, state.radiusExponent);
+  const overviewD = overviewDistance(
+    body.catalogDistance,
+    state.distanceExponent
+  );
+
+  const weight = moonLocalWeight(body, state);
+  if (weight <= 0 || !parent) {
+    return { radius: overviewR, distance: overviewD };
+  }
+
+  return {
+    radius: lerp(
+      overviewR,
+      localRadius(body.catalogRadius, parent.catalogRadius, parent.radius),
+      weight
+    ),
+    distance: lerp(
+      overviewD,
+      localDistance(
+        body.catalogDistance,
+        parent.catalogRadius,
+        parent.radius
+      ),
+      weight
+    ),
+  };
+};
+
+/**
+ * Apply overview exponents and, when a planet (or its moon) is in focus,
+ * lerp that planet's moons toward true size and a 0.75-power of true distance.
+ */
+export const applySceneScale = (
+  solarSystem: SolarSystem,
+  state: ScaleState
+): void => {
+  for (const body of Object.values(solarSystem)) {
+    if (body.type === "ring") {
+      const parent = body.orbits ? solarSystem[body.orbits] : undefined;
+      if (parent) {
+        body.setRingScale(parent.radius);
+      }
+      continue;
+    }
+
+    const parent = body.orbits ? solarSystem[body.orbits] : undefined;
+    const { radius, distance } = sceneSize(body, parent, state);
+    body.setSceneSize(radius, distance);
+  }
+};
+
+export const outerOrbitRadius = (solarSystem: SolarSystem): number => {
+  let max = 0;
+  for (const body of Object.values(solarSystem)) {
+    if (body.type === "planet") {
+      max = Math.max(max, body.distance);
+    }
+  }
+  return max;
+};


### PR DESCRIPTION
- Anchor Earth and add GUI size/distance exponents so overview proportions stay readable while you can slide toward true scale.
- When a planet (or its moon) is in focus, lerp that system's moons toward true size and a 0.75-power of true orbital distance.
- Keep camera far/min distance, rings, POI probes, and orbit trails in sync as scale changes.
- Use quintic ease-in-out for body-to-body travel so the camera coasts into the destination.