### PR TITLE
Add speed control, hide spin in production, and fix Triton's trail

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -83,6 +83,12 @@
       </span>
       <span class="hud-ctrl-label">Pause</span>
     </button>
+    <button class="hud-ctrl hud-ctrl-readout" id="btn-speed" type="button" aria-label="Simulation speed x1">
+      <span class="hud-ctrl-disc" aria-hidden="true">
+        <span class="hud-ctrl-value">x1</span>
+      </span>
+      <span class="hud-ctrl-label">Speed</span>
+    </button>
     <button class="hud-ctrl" id="btn-labels" type="button" aria-label="Show labels" aria-pressed="true">
       <span class="hud-ctrl-disc" aria-hidden="true">
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">

--- a/src/index.html
+++ b/src/index.html
@@ -101,7 +101,8 @@
       </span>
       <span class="hud-ctrl-label">Trails</span>
     </button>
-    <button class="hud-ctrl" id="btn-spin" type="button" aria-label="Ride planet spin" aria-pressed="false">
+    <button class="hud-ctrl" id="btn-spin" type="button" aria-label="Ride planet spin" aria-pressed="false"
+      hidden>
       <span class="hud-ctrl-disc" aria-hidden="true">
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
           <path d="M18.4 12a6.5 6.5 0 1 1-1.9-4.6" />

--- a/src/planets.json
+++ b/src/planets.json
@@ -251,7 +251,7 @@
     "traversable": true,
     "offset": 0,
     "model": "./models/phobos.glb",
-    "description": "Phobos is the inner and larger moon of Mars, an irregular, cratered rock that skims just above the atmosphere. It is tidally locked and slowly spiralling inward; in tens of millions of years it will break apart or strike Mars."
+    "description": "Phobos is the inner and larger moon of Mars, an irregular, cratered rock that skims just above the atmosphere. It is tidally locked and slowly spiralling inward; in tens of millions of years it will break apart."
   },
   {
     "name": "Deimos",

--- a/src/script.ts
+++ b/src/script.ts
@@ -9,7 +9,7 @@ import {
 } from "./setup/lights";
 import { createStarfield } from "./setup/starfield";
 import { createSolarSystem } from "./setup/solar-system";
-import { createGUI, options } from "./setup/gui";
+import { BASE_SPEED, createGUI, options } from "./setup/gui";
 import { createPoiProbe } from "./setup/poi-probe";
 import { isIntroActive, onIntroDismiss } from "./setup/loading";
 import { updateIdentity } from "./setup/identity";
@@ -427,7 +427,7 @@ poiProbe.sync();
   const wallDt = Math.min(0.05, (wall - lastWall) / 1000);
   lastWall = wall;
 
-  elapsedTime += clock.getDelta() * options.speed;
+  elapsedTime += clock.getDelta() * BASE_SPEED * options.speed;
 
   applySceneScale(solarSystem, currentScaleState(wallDt));
   fitCameraToScale();

--- a/src/setup/gui.ts
+++ b/src/setup/gui.ts
@@ -90,23 +90,28 @@ export const createGUI = (
   });
 
   const spinButton = document.getElementById("btn-spin");
-  spinButton?.addEventListener("click", () => {
-    if (isIntroActive()) return;
-    const ride = spinButton.getAttribute("aria-pressed") !== "true";
-    setToggle(spinButton, ride);
-    onRideSpin?.(ride);
-  });
-
   const settingsButton = document.getElementById("btn-settings");
   if (!import.meta.env.DEV) {
+    spinButton?.remove();
     settingsButton?.remove();
-  } else if (settingsButton) {
-    settingsButton.removeAttribute("hidden");
-    settingsButton.addEventListener("click", () => {
-      if (isIntroActive()) return;
-      gui.show(gui._hidden);
-      setToggle(settingsButton, !gui._hidden);
-    });
+  } else {
+    if (spinButton) {
+      spinButton.removeAttribute("hidden");
+      spinButton.addEventListener("click", () => {
+        if (isIntroActive()) return;
+        const ride = spinButton.getAttribute("aria-pressed") !== "true";
+        setToggle(spinButton, ride);
+        onRideSpin?.(ride);
+      });
+    }
+    if (settingsButton) {
+      settingsButton.removeAttribute("hidden");
+      settingsButton.addEventListener("click", () => {
+        if (isIntroActive()) return;
+        gui.show(gui._hidden);
+        setToggle(settingsButton, !gui._hidden);
+      });
+    }
   }
 
   return gui;

--- a/src/setup/gui.ts
+++ b/src/setup/gui.ts
@@ -7,13 +7,23 @@ import {
   DEFAULT_RADIUS_EXPONENT,
 } from "./scale";
 
+export const BASE_SPEED = 0.125;
+export const SPEED_STEPS = [1, 2, 5, 10, 20] as const;
+
 export const options = {
   showPaths: true,
   focus: "Sun",
   clock: true,
-  speed: 0.125,
+  speed: 1,
   radiusExponent: DEFAULT_RADIUS_EXPONENT,
   distanceExponent: DEFAULT_DISTANCE_EXPONENT,
+};
+
+const formatSpeed = (speed: number) => `x${Number(speed)}`;
+
+const nextSpeed = (current: number) => {
+  const index = SPEED_STEPS.findIndex((step) => step === Number(current));
+  return SPEED_STEPS[(index + 1) % SPEED_STEPS.length];
 };
 
 export const createGUI = (
@@ -44,6 +54,17 @@ export const createGUI = (
     }
   };
 
+  const syncSpeedButton = () => {
+    const button = document.getElementById("btn-speed");
+    if (!button) return;
+    const value = formatSpeed(options.speed);
+    button.setAttribute("aria-label", `Simulation speed ${value}`);
+    const readout = button.querySelector(".hud-ctrl-value");
+    if (readout) {
+      readout.textContent = value;
+    }
+  };
+
   const applyRunState = (running: boolean) => {
     options.clock = running;
     if (running) {
@@ -54,7 +75,13 @@ export const createGUI = (
     syncRunButton(running);
   };
 
-  gui.add(options, "speed", 0, 5, 0.01).name("Speed");
+  const speedController = gui
+    .add(options, "speed", SPEED_STEPS)
+    .name("Speed")
+    .onChange(() => {
+      options.speed = Number(options.speed);
+      syncSpeedButton();
+    });
 
   gui
     .add(options, "radiusExponent", DEFAULT_RADIUS_EXPONENT, 1, 0.01)
@@ -73,6 +100,14 @@ export const createGUI = (
   runButton?.addEventListener("click", () => {
     if (isIntroActive()) return;
     applyRunState(!options.clock);
+  });
+
+  const speedButton = document.getElementById("btn-speed");
+  speedButton?.addEventListener("click", () => {
+    if (isIntroActive()) return;
+    options.speed = nextSpeed(options.speed);
+    speedController.updateDisplay();
+    syncSpeedButton();
   });
 
   const labelsButton = document.getElementById("btn-labels");

--- a/src/setup/gui.ts
+++ b/src/setup/gui.ts
@@ -75,14 +75,6 @@ export const createGUI = (
     syncRunButton(running);
   };
 
-  const speedController = gui
-    .add(options, "speed", SPEED_STEPS)
-    .name("Speed")
-    .onChange(() => {
-      options.speed = Number(options.speed);
-      syncSpeedButton();
-    });
-
   gui
     .add(options, "radiusExponent", DEFAULT_RADIUS_EXPONENT, 1, 0.01)
     .name("Size exponent");
@@ -106,7 +98,6 @@ export const createGUI = (
   speedButton?.addEventListener("click", () => {
     if (isIntroActive()) return;
     options.speed = nextSpeed(options.speed);
-    speedController.updateDisplay();
     syncSpeedButton();
   });
 

--- a/src/setup/path.ts
+++ b/src/setup/path.ts
@@ -17,19 +17,23 @@ export const setTrailResolution = (width: number, height: number) => {
 const createTrailGeometry = (
   orbitRadius: number,
   bodyRadius: number,
-  color: THREE.Color
+  color: THREE.Color,
+  retrograde: boolean
 ): LineGeometry => {
   const trailAngle = Math.PI * 2 * TRAIL_FRACTION;
   const gap = Math.asin(
     Math.min(0.85, (bodyRadius * 1.45) / Math.max(orbitRadius, bodyRadius * 2))
   );
+  // Prograde bodies advance toward +theta, so the wake is behind at -theta.
+  // Retrograde orbits (negative period) go the other way.
+  const sign = retrograde ? 1 : -1;
 
   const positions: number[] = [];
   const colors: number[] = [];
 
   for (let i = 0; i <= ARC_SEGS; i++) {
     const t = i / ARC_SEGS;
-    const theta = -(gap + trailAngle * (1 - t));
+    const theta = sign * (gap + trailAngle * (1 - t));
     positions.push(
       Math.sin(theta) * orbitRadius,
       0,
@@ -48,7 +52,8 @@ const createTrailGeometry = (
 export const createPath = (
   orbitRadius: number,
   bodyRadius: number,
-  name: string
+  name: string,
+  retrograde = false
 ): THREE.Mesh => {
   const color = bodyColorThree(name);
   const material = new LineMaterial({
@@ -65,13 +70,17 @@ export const createPath = (
   });
   material.uniforms.resolution.value = trailResolution;
 
-  const mesh = new Line2(createTrailGeometry(orbitRadius, bodyRadius, color), material);
+  const mesh = new Line2(
+    createTrailGeometry(orbitRadius, bodyRadius, color, retrograde),
+    material
+  );
   mesh.visible = false;
   mesh.frustumCulled = false;
   mesh.userData.ignorePick = true;
   mesh.userData.trailOpacity = 0;
   mesh.userData.pathOrbit = orbitRadius;
   mesh.userData.pathBody = bodyRadius;
+  mesh.userData.pathRetrograde = retrograde;
   mesh.renderOrder = 2;
   return mesh;
 };
@@ -87,15 +96,18 @@ export const updatePath = (
   trail: THREE.Mesh,
   orbitRadius: number,
   bodyRadius: number,
-  name: string
+  name: string,
+  retrograde = false
 ) => {
   const prevOrbit = trail.userData.pathOrbit as number | undefined;
   const prevBody = trail.userData.pathBody as number | undefined;
+  const prevRetrograde = trail.userData.pathRetrograde as boolean | undefined;
   if (
     prevOrbit !== undefined &&
     prevBody !== undefined &&
     Math.abs(prevOrbit - orbitRadius) < 1e-8 &&
-    Math.abs(prevBody - bodyRadius) < 1e-8
+    Math.abs(prevBody - bodyRadius) < 1e-8 &&
+    prevRetrograde === retrograde
   ) {
     return;
   }
@@ -104,9 +116,11 @@ export const updatePath = (
   trail.geometry = createTrailGeometry(
     orbitRadius,
     bodyRadius,
-    bodyColorThree(name)
+    bodyColorThree(name),
+    retrograde
   );
   old.dispose();
   trail.userData.pathOrbit = orbitRadius;
   trail.userData.pathBody = bodyRadius;
+  trail.userData.pathRetrograde = retrograde;
 };

--- a/src/setup/planetary-object.ts
+++ b/src/setup/planetary-object.ts
@@ -141,7 +141,12 @@ export class PlanetaryObject {
     this.equator.add(this.mesh);
 
     if (this.orbits && this.distance > 0 && type !== "ring") {
-      this.path = createPath(this.distance, this.radius, body.name);
+      this.path = createPath(
+        this.distance,
+        this.radius,
+        body.name,
+        this.period < 0
+      );
       this.orbit.add(this.path);
     }
 
@@ -179,7 +184,13 @@ export class PlanetaryObject {
       this.mesh.scale.setScalar(radius / this.meshLocalRadius);
     }
     if (this.path) {
-      updatePath(this.path, this.distance, this.radius, this.name);
+      updatePath(
+        this.path,
+        this.distance,
+        this.radius,
+        this.name,
+        this.period < 0
+      );
     }
   };
 

--- a/src/styles/gui.scss
+++ b/src/styles/gui.scss
@@ -98,6 +98,16 @@
   stroke: none;
 }
 
+.hud-ctrl-value {
+  font-family: "IBM Plex Mono", ui-monospace, monospace;
+  font-size: 0.6875rem;
+  font-weight: 400;
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 0.02em;
+  line-height: 1;
+  color: inherit;
+}
+
 .hud-ctrl .icon-play {
   display: none;
 }
@@ -122,7 +132,8 @@
     0 0 0 3px var(--hud-brass);
 }
 
-.hud-ctrl[aria-pressed="true"] .hud-ctrl-disc {
+.hud-ctrl[aria-pressed="true"] .hud-ctrl-disc,
+.hud-ctrl.hud-ctrl-readout .hud-ctrl-disc {
   color: var(--hud-brass);
   transform: scale(1.18);
   box-shadow:
@@ -155,7 +166,9 @@
 }
 
 .hud-ctrl[aria-pressed="true"]:hover .hud-ctrl-label,
-.hud-ctrl[aria-pressed="true"]:focus-visible .hud-ctrl-label {
+.hud-ctrl[aria-pressed="true"]:focus-visible .hud-ctrl-label,
+.hud-ctrl-readout:hover .hud-ctrl-label,
+.hud-ctrl-readout:focus-visible .hud-ctrl-label {
   color: var(--hud-brass);
 }
 
@@ -183,6 +196,10 @@
   .hud-ctrl-label {
     font-size: 0.625rem;
     letter-spacing: 0.04em;
+  }
+
+  .hud-ctrl-value {
+    font-size: 0.625rem;
   }
 
   .hud-ctrl:hover .hud-ctrl-label {


### PR DESCRIPTION
- Add a HUD Speed button that cycles x1, x2, x5, x10, and x20.
- Hide the Spin control in production, matching Settings, so it stays a dev-only camera aid.
- Draw orbit trails behind retrograde bodies so Triton's wake follows its motion around Neptune.