### PR TITLE
Add dayside cloud shadows on Earth

### DIFF
--- a/src/setup/cloud-shadows.ts
+++ b/src/setup/cloud-shadows.ts
@@ -1,16 +1,21 @@
 import * as THREE from "three";
 
-const OUTGOING_LIGHT =
-  "vec3 outgoingLight = totalDiffuse + totalSpecular + totalEmissiveRadiance;";
+const OUTPUT_FRAGMENT = "#include <output_fragment>";
 
 /**
- * Darken the dayside where the cloud alpha is opaque. Applied before night
- * lights so that pass still finds the stock outgoing-light line; city lights
- * then mix from the already-shadowed dayLight.
+ * Darken final dayside colour where the cloud alpha is opaque. Injected just
+ * before output so it runs after night lights have mixed city lights; dayFactor
+ * keeps the night hemisphere untouched.
+ *
+ * Cover is sampled slightly toward the sun and dilated so the shadow falls on
+ * open ground next to cloud banks — otherwise the opaque cloud mesh hides it.
+ *
+ * Patches `#include <output_fragment>` because onBeforeCompile runs before
+ * ShaderChunk includes are resolved (same reason night lights patches the
+ * inline outgoingLight line rather than an include).
  */
-const CLOUD_SHADOW_OUTGOING_LIGHT = /* glsl */ `
-vec2 cloudUv = vec2(fract(vMapUv.x - cloudSpin * RECIPROCAL_PI2), vMapUv.y);
-float cloudCover = texture2D(cloudAlphaMap, cloudUv).g;
+const CLOUD_SHADOW_BEFORE_OUTPUT = /* glsl */ `
+vec2 cloudBaseUv = vec2(fract(vMapUv.x - cloudSpin * RECIPROCAL_PI2), vMapUv.y);
 #if ( NUM_SPOT_LIGHTS > 0 ) || ( NUM_POINT_LIGHTS > 0 )
 	#if ( NUM_SPOT_LIGHTS > 0 )
 		vec3 cloudLightDir = normalize(spotLights[0].position - geometry.position);
@@ -18,13 +23,20 @@ float cloudCover = texture2D(cloudAlphaMap, cloudUv).g;
 		vec3 cloudLightDir = normalize(pointLights[0].position - geometry.position);
 	#endif
 	float cloudDayFactor = smoothstep(-0.05, 0.25, dot(geometry.normal, cloudLightDir));
+	vec2 cloudCast = normalize(vec2(cloudLightDir.x, cloudLightDir.y) + 1e-5) * 0.018;
 #else
 	float cloudDayFactor = 1.0;
+	vec2 cloudCast = vec2(0.0);
 #endif
-float cloudShadow = smoothstep(0.15, 0.75, cloudCover) * cloudDayFactor * cloudShadowStrength;
-totalDiffuse *= 1.0 - cloudShadow;
-totalSpecular *= 1.0 - cloudShadow;
-vec3 outgoingLight = totalDiffuse + totalSpecular + totalEmissiveRadiance;
+vec2 cloudUv = vec2(fract(cloudBaseUv.x + cloudCast.x), clamp(cloudBaseUv.y + cloudCast.y, 0.0, 1.0));
+float cloudCover = texture2D(cloudAlphaMap, cloudUv).g;
+cloudCover = max(cloudCover, texture2D(cloudAlphaMap, cloudUv + vec2(0.018, 0.0)).g);
+cloudCover = max(cloudCover, texture2D(cloudAlphaMap, cloudUv - vec2(0.018, 0.0)).g);
+cloudCover = max(cloudCover, texture2D(cloudAlphaMap, cloudUv + vec2(0.0, 0.018)).g);
+cloudCover = max(cloudCover, texture2D(cloudAlphaMap, cloudUv - vec2(0.0, 0.018)).g);
+float cloudShadow = smoothstep(0.04, 0.4, cloudCover) * cloudDayFactor * cloudShadowStrength;
+outgoingLight *= 1.0 - cloudShadow;
+#include <output_fragment>
 `;
 
 export type CloudShadowUniforms = {
@@ -40,34 +52,44 @@ export type CloudShadowUniforms = {
 export const applyCloudShadows = (
   material: THREE.MeshStandardMaterial,
   cloudAlphaMap: THREE.Texture,
-  strength = 0.45
+  strength = 0.78
 ): CloudShadowUniforms => {
   const uniforms: CloudShadowUniforms = {
     cloudSpin: { value: 0 },
     cloudShadowStrength: { value: strength },
   };
 
+  // Keep the map referenced on the material so the renderer keeps it uploaded
+  // even though only the custom shader samples it.
+  material.userData.cloudAlphaMap = cloudAlphaMap;
+
   const priorCompile = material.onBeforeCompile;
   const priorKey = material.customProgramCacheKey.bind(material);
-  material.customProgramCacheKey = () => `${priorKey()}|cloud-shadows`;
+  material.customProgramCacheKey = () => `${priorKey()}|cloud-shadows-v4`;
   material.onBeforeCompile = (shader, renderer) => {
     priorCompile.call(material, shader, renderer);
     shader.uniforms.cloudAlphaMap = { value: cloudAlphaMap };
     shader.uniforms.cloudSpin = uniforms.cloudSpin;
     shader.uniforms.cloudShadowStrength = uniforms.cloudShadowStrength;
 
-    shader.fragmentShader = shader.fragmentShader
-      .replace(
-        "void main() {",
-        /* glsl */ `
+    const withUniforms = shader.fragmentShader.replace(
+      "void main() {",
+      /* glsl */ `
 uniform sampler2D cloudAlphaMap;
 uniform float cloudSpin;
 uniform float cloudShadowStrength;
 
 void main() {
 `
-      )
-      .replace(OUTGOING_LIGHT, CLOUD_SHADOW_OUTGOING_LIGHT);
+    );
+    const patched = withUniforms.replace(
+      OUTPUT_FRAGMENT,
+      CLOUD_SHADOW_BEFORE_OUTPUT
+    );
+    if (patched === withUniforms || !patched.includes("cloudShadow")) {
+      console.warn("[cloud-shadows] fragment patch did not apply");
+    }
+    shader.fragmentShader = patched;
   };
 
   return uniforms;

--- a/src/setup/cloud-shadows.ts
+++ b/src/setup/cloud-shadows.ts
@@ -1,0 +1,74 @@
+import * as THREE from "three";
+
+const OUTGOING_LIGHT =
+  "vec3 outgoingLight = totalDiffuse + totalSpecular + totalEmissiveRadiance;";
+
+/**
+ * Darken the dayside where the cloud alpha is opaque. Applied before night
+ * lights so that pass still finds the stock outgoing-light line; city lights
+ * then mix from the already-shadowed dayLight.
+ */
+const CLOUD_SHADOW_OUTGOING_LIGHT = /* glsl */ `
+vec2 cloudUv = vec2(fract(vMapUv.x - cloudSpin * RECIPROCAL_PI2), vMapUv.y);
+float cloudCover = texture2D(cloudAlphaMap, cloudUv).g;
+#if ( NUM_SPOT_LIGHTS > 0 ) || ( NUM_POINT_LIGHTS > 0 )
+	#if ( NUM_SPOT_LIGHTS > 0 )
+		vec3 cloudLightDir = normalize(spotLights[0].position - geometry.position);
+	#else
+		vec3 cloudLightDir = normalize(pointLights[0].position - geometry.position);
+	#endif
+	float cloudDayFactor = smoothstep(-0.05, 0.25, dot(geometry.normal, cloudLightDir));
+#else
+	float cloudDayFactor = 1.0;
+#endif
+float cloudShadow = smoothstep(0.15, 0.75, cloudCover) * cloudDayFactor * cloudShadowStrength;
+totalDiffuse *= 1.0 - cloudShadow;
+totalSpecular *= 1.0 - cloudShadow;
+vec3 outgoingLight = totalDiffuse + totalSpecular + totalEmissiveRadiance;
+`;
+
+export type CloudShadowUniforms = {
+  cloudSpin: { value: number };
+  cloudShadowStrength: { value: number };
+};
+
+/**
+ * Soft cloud shadows on the ground. Samples the cloud alpha in surface UV
+ * space with the cloud layer’s relative Y spin so weather and shadow drift
+ * together. Dayside-gated so the night hemisphere is unchanged.
+ */
+export const applyCloudShadows = (
+  material: THREE.MeshStandardMaterial,
+  cloudAlphaMap: THREE.Texture,
+  strength = 0.45
+): CloudShadowUniforms => {
+  const uniforms: CloudShadowUniforms = {
+    cloudSpin: { value: 0 },
+    cloudShadowStrength: { value: strength },
+  };
+
+  const priorCompile = material.onBeforeCompile;
+  const priorKey = material.customProgramCacheKey.bind(material);
+  material.customProgramCacheKey = () => `${priorKey()}|cloud-shadows`;
+  material.onBeforeCompile = (shader, renderer) => {
+    priorCompile.call(material, shader, renderer);
+    shader.uniforms.cloudAlphaMap = { value: cloudAlphaMap };
+    shader.uniforms.cloudSpin = uniforms.cloudSpin;
+    shader.uniforms.cloudShadowStrength = uniforms.cloudShadowStrength;
+
+    shader.fragmentShader = shader.fragmentShader
+      .replace(
+        "void main() {",
+        /* glsl */ `
+uniform sampler2D cloudAlphaMap;
+uniform float cloudSpin;
+uniform float cloudShadowStrength;
+
+void main() {
+`
+      )
+      .replace(OUTGOING_LIGHT, CLOUD_SHADOW_OUTGOING_LIGHT);
+  };
+
+  return uniforms;
+};

--- a/src/setup/planetary-object.ts
+++ b/src/setup/planetary-object.ts
@@ -309,16 +309,16 @@ export class PlanetaryObject {
         applyDaysideRelief(material);
       }
 
-      // Before night lights so that pass still matches the stock combine line.
+      if (maps.nightMap) {
+        applyNightLights(material, maps.nightMap);
+      }
+
+      // After night lights: darkens final outgoingLight; dayFactor spares cities.
       if (maps.atmosphere?.alpha) {
         this.cloudShadowUniforms = applyCloudShadows(
           material,
           maps.atmosphere.alpha
         );
-      }
-
-      if (maps.nightMap) {
-        applyNightLights(material, maps.nightMap);
       }
     }
 

--- a/src/setup/planetary-object.ts
+++ b/src/setup/planetary-object.ts
@@ -5,6 +5,10 @@ import { loadTexture } from "./textures";
 import { decorateModelMeshes, fitModelToRadius, loadGltf } from "./models";
 import { applyNightLights } from "./night-lights";
 import { applyDaysideRelief } from "./dayside-relief";
+import {
+  applyCloudShadows,
+  type CloudShadowUniforms,
+} from "./cloud-shadows";
 import { createAtmosphereGlow } from "./atmosphere-glow";
 import type { Body, BodyType, TexturePaths } from "./catalog";
 import { Label, type PointOfInterest } from "./label";
@@ -86,6 +90,7 @@ export class PlanetaryObject {
   path?: THREE.Mesh;
   rng: number;
   labels!: Label;
+  private cloudShadowUniforms?: CloudShadowUniforms;
 
   constructor(body: Body, parent?: PlanetaryObject) {
     const { radius, distance, period, daylength, cloudPeriod, orbits, type, tilt } =
@@ -304,6 +309,14 @@ export class PlanetaryObject {
         applyDaysideRelief(material);
       }
 
+      // Before night lights so that pass still matches the stock combine line.
+      if (maps.atmosphere?.alpha) {
+        this.cloudShadowUniforms = applyCloudShadows(
+          material,
+          maps.atmosphere.alpha
+        );
+      }
+
       if (maps.nightMap) {
         applyNightLights(material, maps.nightMap);
       }
@@ -385,6 +398,10 @@ export class PlanetaryObject {
     if (this.atmosphereMesh && this.cloudPeriod) {
       this.atmosphereMesh.rotation.y =
         this.getRotation(elapsedTime, this.cloudPeriod) - rotation;
+    }
+
+    if (this.cloudShadowUniforms && this.atmosphereMesh) {
+      this.cloudShadowUniforms.cloudSpin.value = this.atmosphereMesh.rotation.y;
     }
   };
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Soft dayside cloud shadows on Earth by sampling the cloud alpha on the ground material (not shadow maps). Shadows follow the cloud layer’s relative spin and stay off the night side so city lights are unchanged.

## Approach
- New `applyCloudShadows` shader patch (`onBeforeCompile`, same family as night lights / dayside relief)
- Patches `#include <output_fragment>` (includes are not resolved yet at compile hook) and darkens final `outgoingLight`
- Cover sample is sun-offset and dilated so shadows fall on open ground beside banks
- Applied after night lights; `cloudSpin` updated each tick from the atmosphere mesh rotation
- Only bodies with `atmosphereAlpha` (Earth) get the effect

## Test plan
- [x] `#earth` — patch applies (no console warning); dayside darkening near cloud banks
- [x] Night side city lights still work
- [x] Red debug sample path verified sampling, then removed
- [ ] Pause / change speed — shadows drift with clouds
- [ ] Venus unchanged (clouds, no alpha)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a07b54-012b-7eb6-a3bf-159daf5818b9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a07b54-012b-7eb6-a3bf-159daf5818b9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

